### PR TITLE
Mrc-6705 Run Emulator 

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,7 +3,7 @@
 REGISTRY=ghcr.io
 ORG=mrc-ide
 API=mintr
-API_VERSION=main 
+API_VERSION=mrc-6656-model-runs # TODO: revert to main after merging R 
 NETWORK=mint_network
 NAME_REDIS=mint-redis
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,7 +3,7 @@
 REGISTRY=ghcr.io
 ORG=mrc-ide
 API=mintr
-API_VERSION=mrc-6656-model-runs # TODO: revert to main after merging R 
+API_VERSION=main # TODO: revert to main after merging R 
 NETWORK=mint_network
 NAME_REDIS=mint-redis
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,7 +3,7 @@
 REGISTRY=ghcr.io
 ORG=mrc-ide
 API=mintr
-API_VERSION=main # TODO: revert to main after merging R 
+API_VERSION=main
 NETWORK=mint_network
 NAME_REDIS=mint-redis
 

--- a/src/lib/components/dynamic-region-form/DynamicForm.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicForm.svelte
@@ -7,6 +7,7 @@
 	import {
 		checkCrossFieldValidation,
 		coerceDefaults,
+		DEBOUNCE_DELAY,
 		forEachField,
 		forEachGroup,
 		forEachSubGroup,
@@ -19,7 +20,7 @@
 		initialValues: Record<string, FormValue>;
 		hasRunBaseline: boolean;
 		children: Snippet;
-		run: (formValues: Record<string, unknown>) => Promise<EmulatorResults | null>;
+		run: (formValues: Record<string, FormValue>) => Promise<EmulatorResults | null>;
 		process: (formValues: Record<string, FormValue>) => void;
 		submitText: string;
 		isInputsDisabled: boolean;
@@ -73,7 +74,6 @@
 	});
 
 	// Debounced functions
-	const DEBOUNCE_DELAY = 800;
 	const debouncedRun = debounce(run, DEBOUNCE_DELAY);
 	const debouncedProcess = debounce(process, DEBOUNCE_DELAY);
 

--- a/src/lib/components/dynamic-region-form/DynamicForm.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicForm.svelte
@@ -145,7 +145,7 @@
 					try {
 						await run(triggerRunFormValues);
 						collapsePreRunGroups();
-					} catch (error) {
+					} catch (_e) {
 						hasRunBaseline = false;
 					}
 				}}

--- a/src/lib/components/dynamic-region-form/DynamicFormField.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicFormField.svelte
@@ -5,14 +5,14 @@
 	import { Slider } from '$lib/components/ui/slider';
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import Switch from '../ui/switch/switch.svelte';
-	import type { SchemaField } from './types';
+	import type { FormValue, SchemaField } from './types';
 	import { evaluateValueExpression, isDisabled } from './utils';
 
 	interface Props {
 		field: SchemaField;
-		form: Record<string, unknown>;
+		form: Record<string, FormValue>;
 		errors: Record<string, string | null>;
-		onFieldChange: (field: SchemaField, value: unknown) => void;
+		onFieldChange: (field: SchemaField, value: FormValue) => void;
 	}
 	let { field, form, errors, onFieldChange }: Props = $props();
 </script>

--- a/src/lib/components/dynamic-region-form/DynamicFormField.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicFormField.svelte
@@ -16,6 +16,8 @@
 		isInputsDisabled: boolean;
 	}
 	let { field, form, errors, onFieldChange, isInputsDisabled }: Props = $props();
+
+	let isFieldDisabled = $derived(isInputsDisabled || isDisabled(form, field));
 </script>
 
 <div class="flex flex-col gap-2">
@@ -33,7 +35,7 @@
 			min={field.min}
 			max={field.max}
 			step={field.step ?? 'any'}
-			disabled={isInputsDisabled || isDisabled(form, field)}
+			disabled={isFieldDisabled}
 			value={String(form[field.id] ?? '')}
 			aria-invalid={Boolean(errors[field.id])}
 			oninput={(e) => onFieldChange(field, e.currentTarget.value === '' ? '' : Number(e.currentTarget.value))}
@@ -41,7 +43,7 @@
 	{:else if field.type === 'toggle'}
 		<Switch
 			id={field.id}
-			disabled={isInputsDisabled || isDisabled(form, field)}
+			disabled={isFieldDisabled}
 			aria-invalid={Boolean(errors[field.id])}
 			checked={Boolean(form[field.id])}
 			onCheckedChange={(checked) => onFieldChange(field, checked)}
@@ -54,7 +56,7 @@
 				min={field.min}
 				max={field.max}
 				step={field.step ?? 1}
-				disabled={isInputsDisabled || isDisabled(form, field)}
+				disabled={isInputsDisabled}
 				value={Number(form[field.id] ?? 0)}
 				aria-invalid={Boolean(errors[field.id])}
 				onValueChange={(value) => onFieldChange(field, value)}
@@ -68,7 +70,7 @@
 				{@const selectedValues = (form[field.id] as string[]) ?? []}
 				<Label class="inline-flex items-center gap-2 text-sm font-normal">
 					<Checkbox
-						disabled={isInputsDisabled || isDisabled(form, field)}
+						disabled={isInputsDisabled}
 						checked={selectedValues.includes(opt.value)}
 						onCheckedChange={(checked) => {
 							const current = new Set<string>(selectedValues);

--- a/src/lib/components/dynamic-region-form/DynamicFormField.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicFormField.svelte
@@ -60,7 +60,7 @@
 				value={Number(form[field.id] ?? 0)}
 				aria-invalid={Boolean(errors[field.id])}
 				onValueChange={(value) => onFieldChange(field, value)}
-				thumbClass={Boolean(errors[field.id]) ? 'border-destructive' : ''}
+				thumbClass={errors[field.id] ? 'border-destructive' : ''}
 			/>
 			<span class="w-10 text-right text-sm tabular-nums">{form[field.id] as number}{field.unit ?? ''}</span>
 		</div>

--- a/src/lib/components/dynamic-region-form/DynamicFormField.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicFormField.svelte
@@ -13,8 +13,9 @@
 		form: Record<string, FormValue>;
 		errors: Record<string, string | null>;
 		onFieldChange: (field: SchemaField, value: FormValue) => void;
+		isInputsDisabled: boolean;
 	}
-	let { field, form, errors, onFieldChange }: Props = $props();
+	let { field, form, errors, onFieldChange, isInputsDisabled }: Props = $props();
 </script>
 
 <div class="flex flex-col gap-2">
@@ -32,7 +33,7 @@
 			min={field.min}
 			max={field.max}
 			step={field.step ?? 'any'}
-			disabled={isDisabled(form, field)}
+			disabled={isInputsDisabled || isDisabled(form, field)}
 			value={String(form[field.id] ?? '')}
 			aria-invalid={Boolean(errors[field.id])}
 			oninput={(e) => onFieldChange(field, e.currentTarget.value === '' ? '' : Number(e.currentTarget.value))}
@@ -40,7 +41,7 @@
 	{:else if field.type === 'toggle'}
 		<Switch
 			id={field.id}
-			disabled={isDisabled(form, field)}
+			disabled={isInputsDisabled || isDisabled(form, field)}
 			aria-invalid={Boolean(errors[field.id])}
 			checked={Boolean(form[field.id])}
 			onCheckedChange={(checked) => onFieldChange(field, checked)}
@@ -53,7 +54,7 @@
 				min={field.min}
 				max={field.max}
 				step={field.step ?? 1}
-				disabled={isDisabled(form, field)}
+				disabled={isInputsDisabled || isDisabled(form, field)}
 				value={Number(form[field.id] ?? 0)}
 				aria-invalid={Boolean(errors[field.id])}
 				onValueChange={(value) => onFieldChange(field, value)}
@@ -67,7 +68,7 @@
 				{@const selectedValues = (form[field.id] as string[]) ?? []}
 				<Label class="inline-flex items-center gap-2 text-sm font-normal">
 					<Checkbox
-						disabled={isDisabled(form, field)}
+						disabled={isInputsDisabled || isDisabled(form, field)}
 						checked={selectedValues.includes(opt.value)}
 						onCheckedChange={(checked) => {
 							const current = new Set<string>(selectedValues);

--- a/src/lib/components/dynamic-region-form/DynamicFormGroup.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicFormGroup.svelte
@@ -14,6 +14,7 @@
 		collapsedSubGroups: Record<string, boolean>;
 		errors: Record<string, string | null>;
 		onFieldChange: (field: SchemaField, value: FormValue) => void;
+		isInputsDisabled: boolean;
 	}
 
 	let {
@@ -22,7 +23,8 @@
 		collapsedGroups = $bindable(),
 		collapsedSubGroups = $bindable(),
 		errors,
-		onFieldChange
+		onFieldChange,
+		isInputsDisabled
 	}: Props = $props();
 </script>
 
@@ -58,7 +60,15 @@
 			class={['mx-2 flex justify-between gap-6 xl:gap-x-20', group.preRun ? 'flex-row' : 'flex-col']}
 		>
 			{#each group.subGroups as subGroup (subGroup.id)}
-				<DynamicFormSubGroup {subGroup} {group} {form} bind:collapsedSubGroups {errors} {onFieldChange} />
+				<DynamicFormSubGroup
+					{subGroup}
+					{group}
+					{form}
+					bind:collapsedSubGroups
+					{errors}
+					{onFieldChange}
+					{isInputsDisabled}
+				/>
 			{/each}
 		</div>
 	{/if}

--- a/src/lib/components/dynamic-region-form/DynamicFormGroup.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicFormGroup.svelte
@@ -4,16 +4,16 @@
 	import { slide } from 'svelte/transition';
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import DynamicFormSubGroup from './DynamicFormSubGroup.svelte';
-	import type { SchemaField, SchemaGroup } from './types';
+	import type { FormValue, SchemaField, SchemaGroup } from './types';
 	import { isGroupCollapsed } from './utils';
 
 	interface Props {
 		group: SchemaGroup;
-		form: Record<string, unknown>;
+		form: Record<string, FormValue>;
 		collapsedGroups: Record<string, boolean>;
 		collapsedSubGroups: Record<string, boolean>;
 		errors: Record<string, string | null>;
-		onFieldChange: (field: SchemaField, value: unknown) => void;
+		onFieldChange: (field: SchemaField, value: FormValue) => void;
 	}
 
 	let {

--- a/src/lib/components/dynamic-region-form/DynamicFormSubGroup.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicFormSubGroup.svelte
@@ -3,16 +3,16 @@
 	import { slide } from 'svelte/transition';
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import DynamicFormField from './DynamicFormField.svelte';
-	import type { SchemaField, SchemaGroup, SchemaSubGroup } from './types';
+	import type { FormValue, SchemaField, SchemaGroup, SchemaSubGroup } from './types';
 	import { isSubGroupCollapsed } from './utils';
 
 	interface Props {
 		subGroup: SchemaSubGroup;
 		group: SchemaGroup;
 		collapsedSubGroups: Record<string, boolean>;
-		form: Record<string, unknown>;
+		form: Record<string, FormValue>;
 		errors: Record<string, string | null>;
-		onFieldChange: (field: SchemaField, value: unknown) => void;
+		onFieldChange: (field: SchemaField, value: FormValue) => void;
 	}
 
 	let { subGroup, group, form, collapsedSubGroups = $bindable(), errors, onFieldChange }: Props = $props();

--- a/src/lib/components/dynamic-region-form/DynamicFormSubGroup.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicFormSubGroup.svelte
@@ -13,9 +13,18 @@
 		form: Record<string, FormValue>;
 		errors: Record<string, string | null>;
 		onFieldChange: (field: SchemaField, value: FormValue) => void;
+		isInputsDisabled: boolean;
 	}
 
-	let { subGroup, group, form, collapsedSubGroups = $bindable(), errors, onFieldChange }: Props = $props();
+	let {
+		subGroup,
+		group,
+		form,
+		collapsedSubGroups = $bindable(),
+		errors,
+		onFieldChange,
+		isInputsDisabled
+	}: Props = $props();
 </script>
 
 <div class="xl:flex-1">
@@ -54,7 +63,7 @@
 	{#if !isSubGroupCollapsed(collapsedSubGroups, group.id, subGroup.id)}
 		<div id={`subgroup-${group.id}-${subGroup.id}`} class="flex flex-col gap-5" transition:slide>
 			{#each subGroup.fields as field (field.id)}
-				<DynamicFormField {field} {form} {errors} {onFieldChange} />
+				<DynamicFormField {field} {form} {errors} {onFieldChange} {isInputsDisabled} />
 			{/each}
 		</div>
 	{/if}

--- a/src/lib/components/dynamic-region-form/types.ts
+++ b/src/lib/components/dynamic-region-form/types.ts
@@ -78,7 +78,7 @@ export interface SchemaGroup {
 	description: string;
 	helpText?: string;
 	collapsible?: boolean;
-	triggersRerun?: boolean;
+	triggersRun?: boolean;
 	preRun?: boolean;
 	subGroups: SchemaSubGroup[];
 }

--- a/src/lib/components/dynamic-region-form/utils.ts
+++ b/src/lib/components/dynamic-region-form/utils.ts
@@ -152,3 +152,5 @@ export const checkCrossFieldValidation = (
 		else if (errors[fid] === rule.message) errors[fid] = null;
 	}
 };
+
+export const DEBOUNCE_DELAY = 2000;

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,50 @@
+import type { ResponseBody, ResponseBodyFailure, ResponseBodySuccess } from './types/api';
+
+export class ApiError extends Error {
+	status: number;
+
+	constructor(message: string, status: number) {
+		super(message); // Pass the message to the Error constructor
+		this.name = 'ApiError'; // Set the name of the error
+		this.status = status; // Set the status
+	}
+}
+
+export interface Fetcher {
+	url: string;
+	method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+	body?: object;
+	json?: boolean;
+	fetcher?: typeof fetch;
+}
+
+export const apiFetch = async <T>({ url, method = 'GET', body, fetcher = fetch }: Fetcher) => {
+	const res = await fetcher(url, {
+		method,
+		...(body && { body: JSON.stringify(body) }),
+		headers: {
+			Accept: 'application/json',
+			...(body && { 'Content-Type': 'application/json' })
+		}
+	});
+
+	const isJson = res.headers.get('content-type')?.includes('application/json');
+	const data: ResponseBody<T> | null = isJson ? await res.json() : null;
+
+	if (res.ok) {
+		return data as ResponseBodySuccess<T>;
+	}
+
+	if (!data) {
+		throw new ApiError(`Request failed with status ${res.status}`, res.status);
+	}
+
+	if ('message' in data) {
+		throw new ApiError(data.message, res.status);
+	}
+
+	console.error(data);
+	const errors = (data as ResponseBodyFailure).errors;
+	const errorMessage = errors[0]?.detail || errors[0]?.error || 'Unknown error';
+	throw new ApiError(errorMessage, res.status);
+};

--- a/src/lib/server/region.ts
+++ b/src/lib/server/region.ts
@@ -1,10 +1,10 @@
 import type { DynamicFormSchema, FormValue } from '$lib/components/dynamic-region-form/types';
 import { saveUserState } from '$lib/server/redis';
-import type { Region, EmulatorResults, UserState } from '$lib/types/userState';
-import { regionFormUrl, regionUrl } from '$lib/url';
+import type { ResponseBodySuccess } from '$lib/types/api';
+import type { EmulatorResults, Region, UserState } from '$lib/types/userState';
+import { regionFormUrl, runEmulatorUrl } from '$lib/url';
 import { error } from '@sveltejs/kit';
 import type { RequestEvent } from '../../routes/projects/[project]/regions/[region]/$types';
-import type { ResponseBodySuccess } from '$lib/types/api';
 
 export const getRegionFormSchema = async (
 	projectName: string,
@@ -17,7 +17,7 @@ export const getRegionFormSchema = async (
 	return form.data as DynamicFormSchema;
 };
 
-export const runModelsOnLoad = async (
+export const runEmulatorOnLoad = async (
 	projectName: string,
 	regionName: string,
 	regionData: Region,
@@ -25,16 +25,14 @@ export const runModelsOnLoad = async (
 ): Promise<EmulatorResults | null> => {
 	if (!regionData.hasRunBaseline) return null;
 	// if region has run, run models to get time series data
-	const res = await fetch(regionUrl(projectName, regionName), {
+	const res = await fetch(runEmulatorUrl(), {
 		method: 'POST',
-		body: JSON.stringify({
-			formValues: regionData.formValues
-		}),
+		body: JSON.stringify(regionData.formValues),
 		headers: {
 			'Content-Type': 'application/json'
 		}
 	});
-	// todo handle correctly.. refresh form probably
+	// TODO: handle correctly.. refresh form probably
 	if (!res.ok) error(res.status, `Failed to fetch data for region "${regionName}" in project "${projectName}"`);
 	return (await res.json()) as EmulatorResults;
 };

--- a/src/lib/server/region.ts
+++ b/src/lib/server/region.ts
@@ -1,6 +1,6 @@
 import type { DynamicFormSchema, FormValue } from '$lib/components/dynamic-region-form/types';
 import { saveUserState } from '$lib/server/redis';
-import type { Region, RunData, UserState } from '$lib/types/userState';
+import type { Region, EmulatorResults, UserState } from '$lib/types/userState';
 import { regionFormUrl, regionUrl } from '$lib/url';
 import { error } from '@sveltejs/kit';
 import type { RequestEvent } from '../../routes/projects/[project]/regions/[region]/$types';
@@ -22,8 +22,8 @@ export const runModelsOnLoad = async (
 	regionName: string,
 	regionData: Region,
 	fetch: RequestEvent['fetch']
-): Promise<RunData | null> => {
-	if (!regionData.hasRun) return null;
+): Promise<EmulatorResults | null> => {
+	if (!regionData.hasRunBaseline) return null;
 	// if region has run, run models to get time series data
 	const res = await fetch(regionUrl(projectName, regionName), {
 		method: 'POST',
@@ -36,7 +36,7 @@ export const runModelsOnLoad = async (
 	});
 	// todo handle correctly.. refresh form probably
 	if (!res.ok) error(res.status, `Failed to fetch data for region "${regionName}" in project "${projectName}"`);
-	return (await res.json()) as RunData;
+	return (await res.json()) as EmulatorResults;
 };
 
 export const saveRegionFormState = async (
@@ -47,7 +47,7 @@ export const saveRegionFormState = async (
 ) => {
 	const regionData = getValidatedRegionData(userState, projectName, regionName);
 	regionData.formValues = formValues;
-	regionData.hasRun = true;
+	regionData.hasRunBaseline = true;
 	await saveUserState(userState);
 };
 

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -6,9 +6,9 @@ export interface ResponseBodyFailure {
 		detail: string | null;
 	}[];
 }
-export interface ResponseBodySuccess {
+export interface ResponseBodySuccess<T> {
 	status: 'success';
-	data: unknown;
+	data: T;
 	errors: null;
 }
-export type ResponseBody = ResponseBodySuccess | ResponseBodyFailure;
+export type ResponseBody<T> = ResponseBodySuccess<T> | ResponseBodyFailure;

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -11,4 +11,4 @@ export interface ResponseBodySuccess<T> {
 	data: T;
 	errors: null;
 }
-export type ResponseBody<T> = ResponseBodySuccess<T> | ResponseBodyFailure;
+export type ResponseBody<T> = ResponseBodySuccess<T> | ResponseBodyFailure | App.Error;

--- a/src/lib/types/userState.ts
+++ b/src/lib/types/userState.ts
@@ -8,7 +8,7 @@ export interface PrevalenceData {
 export interface CasesData {
 	scenario: string;
 	year: number;
-	cases_per_1000: number;
+	casesPer1000: number;
 }
 export interface EmulatorResults {
 	prevalence: PrevalenceData[];

--- a/src/lib/types/userState.ts
+++ b/src/lib/types/userState.ts
@@ -1,9 +1,20 @@
 import type { FormValue } from '$lib/components/dynamic-region-form/types';
 
-export interface RunData {
-	prevalenceData: Record<string, unknown[]>; // key of run and timeseries value
-	casesData: Record<string, unknown[]>; // key of run and timeseries value
+export interface PrevalenceData {
+	scenario: string;
+	days: number;
+	prevalence: number;
 }
+export interface CasesData {
+	scenario: string;
+	year: number;
+	cases: number;
+}
+export interface RunData {
+	prevalence: PrevalenceData[];
+	cases: CasesData[];
+}
+
 export interface Region {
 	name: string;
 	hasRun: boolean;

--- a/src/lib/types/userState.ts
+++ b/src/lib/types/userState.ts
@@ -10,14 +10,14 @@ export interface CasesData {
 	year: number;
 	cases: number;
 }
-export interface RunData {
+export interface EmulatorResults {
 	prevalence: PrevalenceData[];
 	cases: CasesData[];
 }
 
 export interface Region {
 	name: string;
-	hasRun: boolean;
+	hasRunBaseline: boolean;
 	formValues: Record<string, FormValue>;
 }
 export interface Project {

--- a/src/lib/types/userState.ts
+++ b/src/lib/types/userState.ts
@@ -8,7 +8,7 @@ export interface PrevalenceData {
 export interface CasesData {
 	scenario: string;
 	year: number;
-	cases: number;
+	cases_per_1000: number;
 }
 export interface EmulatorResults {
 	prevalence: PrevalenceData[];

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -2,3 +2,4 @@ import { PUBLIC_MINTR_URL } from '$env/static/public';
 
 export const regionUrl = (projectName: string, regionName: string) => `/projects/${projectName}/regions/${regionName}`;
 export const regionFormUrl = () => PUBLIC_MINTR_URL + '/options';
+export const runEmulatorUrl = () => PUBLIC_MINTR_URL + '/emulator/run';

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -33,7 +33,7 @@ export const actions: Actions = {
 			regions: form.data.regions.map((region) => ({
 				name: region,
 				formValues: {},
-				hasRun: false
+				hasRunBaseline: false
 			})),
 			budget: 2000000, // default budget (TODO: place somewhere better with other defaults)
 			canStrategize: false

--- a/src/routes/projects/[project]/regions/[region]/+page.server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+page.server.ts
@@ -17,7 +17,7 @@ export const load: PageServerLoad = async ({ params, locals, fetch }) => {
 		formSchema: await getRegionFormSchema(project, region, fetch),
 		region: regionData,
 		addRegionForm,
-		runPromise: runEmulatorOnLoad(project, region, regionData, fetch) // stream as it resolves
+		runPromise: runEmulatorOnLoad(regionData, fetch) // stream as it resolves
 	};
 };
 export const actions: Actions = {

--- a/src/routes/projects/[project]/regions/[region]/+page.server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+page.server.ts
@@ -42,7 +42,7 @@ export const actions: Actions = {
 		projectData.regions.push({
 			name: addRegionForm.data.name,
 			formValues: {},
-			hasRun: false
+			hasRunBaseline: false
 		});
 
 		return redirect(303, regionUrl(projectData.name, addRegionForm.data.name));

--- a/src/routes/projects/[project]/regions/[region]/+page.server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+page.server.ts
@@ -1,4 +1,4 @@
-import { getRegionFormSchema, getValidatedRegionData, runModelsOnLoad } from '$lib/server/region';
+import { getRegionFormSchema, getValidatedRegionData, runEmulatorOnLoad } from '$lib/server/region';
 import { regionUrl } from '$lib/url';
 import { addRegionSchema } from '$routes/projects/[project]/regions/[region]/schema';
 import { redirect, type Actions } from '@sveltejs/kit';
@@ -17,8 +17,7 @@ export const load: PageServerLoad = async ({ params, locals, fetch }) => {
 		formSchema: await getRegionFormSchema(project, region, fetch),
 		region: regionData,
 		addRegionForm,
-		// TODO: will go directly to R api to run
-		runPromise: runModelsOnLoad(project, region, regionData, fetch) // stream as it resolves
+		runPromise: runEmulatorOnLoad(project, region, regionData, fetch) // stream as it resolves
 	};
 };
 export const actions: Actions = {

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -6,6 +6,7 @@
 	import { regionUrl } from '$lib/url';
 	import type { EmulatorResults } from '$lib/types/userState';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
+	import { apiFetch } from '$lib/fetch';
 
 	let { data, params }: PageProps = $props();
 
@@ -16,19 +17,15 @@
 	const runEmulator = async (formValues: Record<string, FormValue>): Promise<EmulatorResults> => {
 		isRunning = true;
 		try {
-			const res = await fetch(regionUrl(params.project, params.region), {
+			const res = await apiFetch<EmulatorResults>({
+				url: regionUrl(params.project, params.region),
 				method: 'POST',
-				body: JSON.stringify({ formValues }),
-				headers: { 'Content-Type': 'application/json' }
+				body: { formValues }
 			});
 
-			if (!res.ok) {
-				throw new Error('Non-OK response');
-			}
 			isRunning = false;
-			return await res.json();
+			return res.data;
 		} catch (e) {
-			console.error('Failed to process models:', e);
 			toast.error(`Failed to process models for region "${params.region}" in project "${params.project}"`);
 			isRunning = false;
 			throw e;

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -4,16 +4,16 @@
 	import { toast } from 'svelte-sonner';
 	import type { PageProps } from './$types';
 	import { regionUrl } from '$lib/url';
-	import type { RunData } from '$lib/types/userState';
+	import type { EmulatorResults } from '$lib/types/userState';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
 
 	let { data, params }: PageProps = $props();
 
-	let hasRun = $derived(data.region.hasRun);
+	let hasRunBaseline = $derived(data.region.hasRunBaseline);
 	let runPromise = $derived(data.runPromise);
 
 	// TODO: disable inputs when processing model runs. only submit triggers info
-	const runEmulator = async (formValues: Record<string, unknown>): Promise<RunData> => {
+	const runEmulator = async (formValues: Record<string, unknown>): Promise<EmulatorResults> => {
 		try {
 			const res = await fetch(regionUrl(params.project, params.region), {
 				method: 'POST',
@@ -40,7 +40,7 @@
 	<DynamicForm
 		schema={data.formSchema}
 		initialValues={data.region.formValues}
-		bind:hasRun
+		bind:hasRunBaseline
 		run={(formValues) => (runPromise = runEmulator(formValues))}
 		process={processCosts}
 		submitText="Run baseline"
@@ -49,9 +49,9 @@
 			<div class="flex items-center justify-center p-8">
 				<div class="text-muted-foreground">Loading results...</div>
 			</div>
-		{:then runData}
-			{#if runData}
-				{JSON.stringify(runData)}
+		{:then emulatorResults}
+			{#if emulatorResults}
+				{JSON.stringify(emulatorResults)}
 			{/if}
 		{:catch _err}
 			<div class="flex items-center justify-center p-8">

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -13,7 +13,7 @@
 	let hasRunBaseline = $derived(data.region.hasRunBaseline);
 	let runPromise = $derived(data.runPromise);
 
-	const runEmulator = async (formValues: Record<string, unknown>): Promise<EmulatorResults> => {
+	const runEmulator = async (formValues: Record<string, FormValue>): Promise<EmulatorResults> => {
 		isRunning = true;
 		try {
 			const res = await fetch(regionUrl(params.project, params.region), {

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -21,6 +21,7 @@
 				body: JSON.stringify({ formValues }),
 				headers: { 'Content-Type': 'application/json' }
 			});
+
 			if (!res.ok) {
 				throw new Error('Non-OK response');
 			}
@@ -59,6 +60,10 @@
 		{:then emulatorResults}
 			{#if emulatorResults}
 				{JSON.stringify(emulatorResults)}
+			{:else}
+				<div class="flex items-center justify-center p-8">
+					<div class="text-destructive">Failed to load results.</div>
+				</div>
 			{/if}
 		{:catch _err}
 			<div class="flex items-center justify-center p-8">

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -51,7 +51,10 @@
 	>
 		{#await runPromise}
 			<div class="flex items-center justify-center p-8">
-				<div class="text-muted-foreground">Loading results...</div>
+				<div class="flex flex-col items-center gap-3">
+					<div class="h-8 w-8 animate-spin rounded-full border-2 border-muted border-t-primary"></div>
+					<div class="text-sm text-muted-foreground">Running...</div>
+				</div>
 			</div>
 		{:then emulatorResults}
 			{#if emulatorResults}

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -26,7 +26,7 @@
 			isRunning = false;
 			return res.data;
 		} catch (e) {
-			toast.error(`Failed to process models for region "${params.region}" in project "${params.project}"`);
+			toast.error(`Failed to run emulator for region "${params.region}" in project "${params.project}"`);
 			isRunning = false;
 			throw e;
 		}

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -9,11 +9,12 @@
 
 	let { data, params }: PageProps = $props();
 
+	let isRunning = $state(false);
 	let hasRunBaseline = $derived(data.region.hasRunBaseline);
 	let runPromise = $derived(data.runPromise);
 
-	// TODO: disable inputs when processing model runs. only submit triggers info
 	const runEmulator = async (formValues: Record<string, unknown>): Promise<EmulatorResults> => {
+		isRunning = true;
 		try {
 			const res = await fetch(regionUrl(params.project, params.region), {
 				method: 'POST',
@@ -23,10 +24,12 @@
 			if (!res.ok) {
 				throw new Error('Non-OK response');
 			}
+			isRunning = false;
 			return await res.json();
 		} catch (e) {
 			console.error('Failed to process models:', e);
 			toast.error(`Failed to process models for region "${params.region}" in project "${params.project}"`);
+			isRunning = false;
 			throw e;
 		}
 	};
@@ -43,6 +46,7 @@
 		bind:hasRunBaseline
 		run={(formValues) => (runPromise = runEmulator(formValues))}
 		process={processCosts}
+		isInputsDisabled={isRunning}
 		submitText="Run baseline"
 	>
 		{#await runPromise}

--- a/src/routes/projects/[project]/regions/[region]/+server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+server.ts
@@ -2,6 +2,8 @@ import { saveRegionFormState } from '$lib/server/region';
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { runEmulatorUrl } from '$lib/url';
+import type { EmulatorResults } from '$lib/types/userState';
+import type { ResponseBody } from '$lib/types/api';
 
 /**
  * Handle POST requests to run models for a specific region in a project.
@@ -18,12 +20,12 @@ export const POST: RequestHandler = async ({ request, locals, params, fetch }) =
 		headers: { 'Content-Type': 'application/json' }
 	});
 
-	const data = await res.json();
+	const body = (await res.json()) as ResponseBody<EmulatorResults>;
 	if (!res.ok) {
-		console.error(data);
+		console.error(body);
 		error(res.status, 'Failed to run emulator for region');
 	}
 	await saveRegionFormState(locals.userState, project, region, formValues);
 
-	return json(data);
+	return json(body.data);
 };

--- a/src/routes/projects/[project]/regions/[region]/+server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+server.ts
@@ -1,50 +1,29 @@
 import { saveRegionFormState } from '$lib/server/region';
-import { json } from '@sveltejs/kit';
+import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { runEmulatorUrl } from '$lib/url';
 
 /**
  * Handle POST requests to run models for a specific region in a project.
  *
  * @returns A JSON response with the time series data for the region.
  */
-export const POST: RequestHandler = async ({ request, locals, params }) => {
-	const { formValues, triggerRun = true } = await request.json();
+export const POST: RequestHandler = async ({ request, locals, params, fetch }) => {
+	const { formValues } = await request.json();
 	const { project, region } = params;
-	// TODO: depending on if model params changed or not then call another endpoint that just updates cost calculation (cost)
-	console.log(triggerRun, 'triggerRun');
-	// simulate delay to run model and fetch time series data. TODO: will be getting from r api
-	await new Promise((resolve) => setTimeout(resolve, 2000));
-	const { dummyCasesData, dummyPrevalenceData } = getDummyRunData();
 
+	const res = await fetch(runEmulatorUrl(), {
+		method: 'POST',
+		body: JSON.stringify(formValues),
+		headers: { 'Content-Type': 'application/json' }
+	});
+
+	const data = await res.json();
+	if (!res.ok) {
+		console.error(data);
+		error(res.status, 'Failed to run emulator for region');
+	}
 	await saveRegionFormState(locals.userState, project, region, formValues);
 
-	return json({ prevalenceData: dummyPrevalenceData, casesData: dummyCasesData });
-};
-
-// create dummy timeseries data for prevalenceData and casesData that is keyed
-// by run and timeseries value
-// TODO: remove after hooked with R
-const getDummyRunData = () => {
-	const dummyPrevalenceData = {
-		run1: [
-			{ id: crypto.randomUUID(), value: Math.floor(Math.random() * 200) + 50 },
-			{ id: crypto.randomUUID(), value: Math.floor(Math.random() * 200) + 50 }
-		],
-		run2: [
-			{ id: crypto.randomUUID(), value: Math.floor(Math.random() * 200) + 50 },
-			{ id: crypto.randomUUID(), value: Math.floor(Math.random() * 200) + 50 }
-		]
-	};
-	const dummyCasesData = {
-		run1: [
-			{ id: crypto.randomUUID(), value: Math.floor(Math.random() * 100) + 10 },
-			{ id: crypto.randomUUID(), value: Math.floor(Math.random() * 100) + 10 }
-		],
-		run2: [
-			{ id: crypto.randomUUID(), value: Math.floor(Math.random() * 100) + 10 },
-			{ id: crypto.randomUUID(), value: Math.floor(Math.random() * 100) + 10 }
-		]
-	};
-
-	return { dummyPrevalenceData, dummyCasesData };
+	return json(data);
 };


### PR DESCRIPTION
This PR comes hand in hand with [mintr](https://github.com/mrc-ide/mintr/pull/104). It now goes and runs emulator and returns the result rather than just using dummy data. The following is also updated:
- run only when triggerRun form field is changed
- disable inputs whilst running 
- add processCosts function
- have added `apiFetch` utility to handle fetches + throwing errors

Testing:
This is point to mintr branch with changes. Thus for testing just play around with form and see prevelance and cases data come back