### PR TITLE
Mrc-6762 Display Costs 

### DIFF
--- a/src/lib/charts/baseChart.ts
+++ b/src/lib/charts/baseChart.ts
@@ -144,3 +144,16 @@ export const ScenarioToColor: Record<Scenario, string> = {
 	py_ppf_only: 'var(--chart-6)',
 	py_ppf_with_lsm: 'var(--chart-6)'
 };
+
+export const getColumnColor = (scenario: Scenario) => ({
+	pattern: {
+		color: ScenarioToColor[scenario],
+		width: 10,
+		height: 10,
+		...(scenario.includes('lsm') && {
+			path: {
+				d: 'M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11'
+			}
+		})
+	}
+});

--- a/src/lib/charts/baseChart.ts
+++ b/src/lib/charts/baseChart.ts
@@ -145,7 +145,7 @@ export const ScenarioToColor: Record<Scenario, string> = {
 	py_ppf_with_lsm: 'var(--chart-6)'
 };
 
-export const getColumnColor = (scenario: Scenario) => ({
+export const getColumnFill = (scenario: Scenario): Highcharts.PatternObject => ({
 	pattern: {
 		color: ScenarioToColor[scenario],
 		width: 10,

--- a/src/lib/charts/casesConfig.ts
+++ b/src/lib/charts/casesConfig.ts
@@ -14,7 +14,7 @@ const getCasesSeriesData = (
 			type: 'column',
 			data: scenarios.map((scenario) => ({
 				name: ScenarioToLabel[scenario],
-				y: casesAverted[scenario]!.casesAvertedMeanPer1000,
+				y: casesAverted[scenario]?.casesAvertedMeanPer1000,
 				color: {
 					pattern: {
 						color: ScenarioToColor[scenario],

--- a/src/lib/charts/casesConfig.ts
+++ b/src/lib/charts/casesConfig.ts
@@ -1,7 +1,7 @@
 import type { CasesAverted } from '$lib/process-results/processCases';
 import type { Scenario } from '$lib/types/userState';
 import type { Options, SeriesColumnOptions, SeriesLineOptions } from 'highcharts';
-import { getColumnColor, ScenarioToLabel } from './baseChart';
+import { getColumnFill, ScenarioToLabel } from './baseChart';
 
 const getCasesSeriesData = (
 	casesAverted: Partial<Record<Scenario, CasesAverted>>
@@ -15,7 +15,7 @@ const getCasesSeriesData = (
 			data: scenarios.map((scenario) => ({
 				name: ScenarioToLabel[scenario],
 				y: casesAverted[scenario]?.casesAvertedMeanPer1000,
-				color: getColumnColor(scenario)
+				color: getColumnFill(scenario)
 			}))
 		},
 		...scenarios.map((scenario, scenarioIndex) => ({

--- a/src/lib/charts/casesConfig.ts
+++ b/src/lib/charts/casesConfig.ts
@@ -1,7 +1,7 @@
 import type { CasesAverted } from '$lib/process-results/processCases';
 import type { Scenario } from '$lib/types/userState';
-import type { SeriesLineOptions, SeriesColumnOptions, Options } from 'highcharts';
-import { ScenarioToColor, ScenarioToLabel } from './baseChart';
+import type { Options, SeriesColumnOptions, SeriesLineOptions } from 'highcharts';
+import { getColumnColor, ScenarioToLabel } from './baseChart';
 
 const getCasesSeriesData = (
 	casesAverted: Partial<Record<Scenario, CasesAverted>>
@@ -15,18 +15,7 @@ const getCasesSeriesData = (
 			data: scenarios.map((scenario) => ({
 				name: ScenarioToLabel[scenario],
 				y: casesAverted[scenario]?.casesAvertedMeanPer1000,
-				color: {
-					pattern: {
-						color: ScenarioToColor[scenario],
-						width: 10,
-						height: 10,
-						...(scenario.includes('lsm') && {
-							path: {
-								d: 'M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11'
-							}
-						})
-					}
-				}
+				color: getColumnColor(scenario)
 			}))
 		},
 		...scenarios.map((scenario, scenarioIndex) => ({

--- a/src/lib/charts/costsConfig.ts
+++ b/src/lib/charts/costsConfig.ts
@@ -1,0 +1,48 @@
+import type { CasesAverted } from '$lib/process-results/processCases';
+import type { Scenario } from '$lib/types/userState';
+import { ScenarioToColor, ScenarioToLabel } from './baseChart';
+
+export const createCostsPer1000Series = (
+	totalCosts: Partial<Record<Scenario, number>>,
+	casesAverted: Partial<Record<Scenario, CasesAverted>>,
+	population: number
+): Highcharts.SeriesScatterOptions[] =>
+	(Object.keys(casesAverted) as Scenario[])
+		.filter((scenario) => casesAverted[scenario] && totalCosts[scenario] !== undefined) // safety check
+		.map((scenario) => ({
+			name: ScenarioToLabel[scenario],
+			color: ScenarioToColor[scenario],
+			type: 'scatter',
+			marker: { symbol: scenario.includes('lsm') ? 'diamond' : 'circle', radius: 6 },
+			data: [
+				[(casesAverted[scenario]!.totalAvertedCases / population) * 1000, (totalCosts[scenario]! / population) * 1000]
+			]
+		}));
+
+export const getCostPer1000Config = (
+	totalCosts: Partial<Record<Scenario, number>>,
+	casesAverted: Partial<Record<Scenario, CasesAverted>>,
+	population: number
+): Highcharts.Options => ({
+	chart: {
+		height: 500,
+		type: 'scatter'
+	},
+	title: {
+		text: 'Strategy cost over 3 years vs cases averted'
+	},
+	xAxis: {
+		title: {
+			text: 'Cases averted per 1,000 people over 3 years'
+		}
+	},
+	yAxis: {
+		title: {
+			text: 'Costs per 1,000 people over 3 years (USD)'
+		}
+	},
+	tooltip: {
+		pointFormat: 'Cases averted: <b>{point.x:.1f}</b><br/>Cost: <b>${point.y:,.1f}</b>'
+	},
+	series: createCostsPer1000Series(totalCosts, casesAverted, population)
+});

--- a/src/lib/charts/costsConfig.ts
+++ b/src/lib/charts/costsConfig.ts
@@ -13,7 +13,12 @@ const createCostsPer1000Series = (
 		color: ScenarioToColor[scenario as Scenario],
 		type: 'scatter',
 		marker: { symbol: scenario.includes('lsm') ? 'diamond' : 'circle', radius: 6 },
-		data: [[casesAverted.totalAvertedCasesPer1000, convertTotalToPer1000(totalCost, population)]]
+		data: [
+			[
+				Number(casesAverted.totalAvertedCasesPer1000.toFixed(2)),
+				Number(convertTotalToPer1000(totalCost, population).toFixed(2))
+			]
+		]
 	}));
 
 const getCostPer1000Config = (
@@ -30,6 +35,9 @@ const getCostPer1000Config = (
 	xAxis: {
 		title: {
 			text: 'Cases averted per 1,000 people over 3 years'
+		},
+		labels: {
+			format: '{value:.2f}'
 		}
 	},
 	yAxis: {

--- a/src/lib/charts/costsConfig.ts
+++ b/src/lib/charts/costsConfig.ts
@@ -1,14 +1,16 @@
 import type { CasesAverted } from '$lib/process-results/processCases';
 import type { Scenario } from '$lib/types/userState';
-import { ScenarioToColor, ScenarioToLabel } from './baseChart';
+import { getColumnColor, ScenarioToColor, ScenarioToLabel } from './baseChart';
 import type { SeriesScatterOptions, SeriesColumnOptions, Options } from 'highcharts';
 
 const createCostsPer1000Series = (
 	totalCosts: Partial<Record<Scenario, number>>,
 	casesAverted: Partial<Record<Scenario, CasesAverted>>,
 	population: number
-): SeriesScatterOptions[] =>
-	(Object.keys(casesAverted) as Scenario[])
+): SeriesScatterOptions[] => {
+	const scenarios = Object.keys(casesAverted) as Scenario[];
+
+	return scenarios
 		.filter((scenario) => casesAverted[scenario] && totalCosts[scenario]) // safety check
 		.map((scenario) => ({
 			name: ScenarioToLabel[scenario],
@@ -17,6 +19,7 @@ const createCostsPer1000Series = (
 			marker: { symbol: scenario.includes('lsm') ? 'diamond' : 'circle', radius: 6 },
 			data: [[casesAverted[scenario]!.totalAvertedCasesPer1000, (totalCosts[scenario]! / population) * 1000]]
 		}));
+};
 
 const getCostPer1000Config = (
 	totalCosts: Partial<Record<Scenario, number>>,
@@ -54,28 +57,17 @@ const getCostPerCaseSeries = (
 	const scenarios = Object.keys(casesAverted) as Scenario[];
 	return [
 		{
-			name: 'Mean',
+			name: 'Cost',
 			type: 'column',
 			data: scenarios
 				.filter((scenario) => casesAverted[scenario] && totalCosts[scenario]) // safety check
 				.map((scenario) => ({
 					name: ScenarioToLabel[scenario],
 					y: totalCosts[scenario]! / ((casesAverted[scenario]!.totalAvertedCasesPer1000 / 1000) * population),
-					color: {
-						pattern: {
-							color: ScenarioToColor[scenario],
-							width: 10,
-							height: 10,
-							...(scenario.includes('lsm') && {
-								path: {
-									d: 'M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11'
-								}
-							})
-						}
-					},
+					color: getColumnColor(scenario),
 					dataLabels: {
 						enabled: true,
-						format: '${point.y:.0f}'
+						format: '${point.y:.1f}'
 					}
 				}))
 		}

--- a/src/lib/charts/costsConfig.ts
+++ b/src/lib/charts/costsConfig.ts
@@ -1,4 +1,4 @@
-import type { CasesAverted } from '$lib/process-results/processCases';
+import { convertPer1000ToTotal, convertTotalToPer1000, type CasesAverted } from '$lib/process-results/processCases';
 import type { Scenario } from '$lib/types/userState';
 import { getColumnColor, ScenarioToColor, ScenarioToLabel } from './baseChart';
 import type { SeriesScatterOptions, SeriesColumnOptions, Options } from 'highcharts';
@@ -17,7 +17,9 @@ const createCostsPer1000Series = (
 			color: ScenarioToColor[scenario],
 			type: 'scatter',
 			marker: { symbol: scenario.includes('lsm') ? 'diamond' : 'circle', radius: 6 },
-			data: [[casesAverted[scenario]!.totalAvertedCasesPer1000, (totalCosts[scenario]! / population) * 1000]]
+			data: [
+				[casesAverted[scenario]!.totalAvertedCasesPer1000, convertTotalToPer1000(totalCosts[scenario]!, population)]
+			]
 		}));
 };
 
@@ -63,7 +65,8 @@ const getCostPerCaseSeries = (
 				.filter((scenario) => casesAverted[scenario] && totalCosts[scenario]) // safety check
 				.map((scenario) => ({
 					name: ScenarioToLabel[scenario],
-					y: totalCosts[scenario]! / ((casesAverted[scenario]!.totalAvertedCasesPer1000 / 1000) * population),
+					y:
+						totalCosts[scenario]! / convertPer1000ToTotal(casesAverted[scenario]!.totalAvertedCasesPer1000, population),
 					color: getColumnColor(scenario),
 					dataLabels: {
 						enabled: true,

--- a/src/lib/components/dynamic-region-form/DynamicForm.svelte
+++ b/src/lib/components/dynamic-region-form/DynamicForm.svelte
@@ -94,9 +94,9 @@
 
 		const group = fieldToGroup[field.id];
 		if (group.triggersRun) {
-			debouncedRun(form);
+			debouncedRun($state.snapshot(form));
 		} else {
-			debouncedProcess(form);
+			debouncedProcess($state.snapshot(form));
 		}
 	};
 	const collapsePreRunGroups = () => {

--- a/src/lib/process-results/costs.ts
+++ b/src/lib/process-results/costs.ts
@@ -1,5 +1,6 @@
 import type { FormValue } from '$lib/components/dynamic-region-form/types';
 import { POST_INTERVENTION_YEARS, type Scenario } from '$lib/types/userState';
+import type { CasesAverted } from './processCases';
 
 /** Fallback values for cost calculations, taken from mintr default */
 export const DEFAULT_POPULATION = 20000;
@@ -127,3 +128,18 @@ export const getTotalCostsPerScenario = (
 		{} as Partial<Record<Scenario, number>>
 	);
 };
+
+export interface CostCasesAndAverted {
+	totalCost: number;
+	casesAverted: CasesAverted;
+}
+
+export const combineCostsAndCasesAverted = (
+	totalCosts: Partial<Record<Scenario, number>>,
+	casesAverted: Partial<Record<Scenario, CasesAverted>>
+): Partial<Record<Scenario, CostCasesAndAverted>> =>
+	Object.fromEntries(
+		(Object.keys(totalCosts) as Scenario[])
+			.filter((scenario) => totalCosts[scenario] !== undefined && casesAverted[scenario])
+			.map((scenario) => [scenario, { totalCost: totalCosts[scenario], casesAverted: casesAverted[scenario] }])
+	);

--- a/src/lib/process-results/processCases.ts
+++ b/src/lib/process-results/processCases.ts
@@ -13,7 +13,7 @@ export const getMeanCasesPostIntervention = (postInterventionCases: CasesData[])
 	postInterventionCases.reduce((sum, c) => sum + c.casesPer1000, 0) / postInterventionCases.length;
 
 // Group cases by scenario, filtering out year 1 (pre-intervention year)
-export const collectPostInterventionCases = (cases: CasesData[]) => {
+export const collectPostInterventionCases = (cases: CasesData[]): Record<Scenario, CasesData[]> => {
 	return cases.reduce(
 		(acc, c) => {
 			if (c.year > PRE_INTERVENTION_YEAR) {
@@ -60,3 +60,6 @@ export const getAvertedCasesData = (
 
 	return casesAverted;
 };
+
+export const convertPer1000ToTotal = (per1000: number, population: number) => (per1000 / 1000) * population;
+export const convertTotalToPer1000 = (total: number, population: number) => (total / population) * 1000;

--- a/src/lib/tables/costTable.ts
+++ b/src/lib/tables/costTable.ts
@@ -2,13 +2,13 @@ import { renderComponent } from '$lib/components/ui/data-table';
 import type { ColumnDef } from '@tanstack/table-core';
 import DataTableSortHeader from '$lib/components/data-table/DataTableSortHeader.svelte';
 import type { Scenario } from '$lib/types/userState';
-import type { CasesAverted } from '$lib/process-results/processCases';
+import { convertPer1000ToTotal, type CasesAverted } from '$lib/process-results/processCases';
 import { ScenarioToLabel } from '$lib/charts/baseChart';
 
 export interface CostTableMetrics {
 	intervention: string;
 	casesAvertedTotal: number;
-	totalCosts: number;
+	totalCost: number;
 	costPerCaseAverted: number;
 }
 export const buildCostTableData = (
@@ -20,20 +20,22 @@ export const buildCostTableData = (
 
 	return scenarios
 		.filter((scenario) => casesAverted[scenario] && totalCosts[scenario]) // safety check
-		.map((scenario) => ({
-			intervention: ScenarioToLabel[scenario],
-			casesAvertedTotal: (casesAverted[scenario]!.totalAvertedCasesPer1000 / 1000) * population,
-			totalCosts: totalCosts[scenario]!,
-			costPerCaseAverted:
-				totalCosts[scenario]! / ((casesAverted[scenario]!.totalAvertedCasesPer1000 / 1000) * population)
-		}));
+		.map((scenario) => {
+			const casesAvertedTotal = convertPer1000ToTotal(casesAverted[scenario]!.totalAvertedCasesPer1000, population);
+			return {
+				intervention: ScenarioToLabel[scenario],
+				casesAvertedTotal,
+				totalCost: totalCosts[scenario]!,
+				costPerCaseAverted: totalCosts[scenario]! / casesAvertedTotal
+			};
+		});
 };
 
 const CostTableInfo: Record<keyof CostTableMetrics, { label: string; formatStyle: 'string' | 'decimal' | 'currency' }> =
 	{
 		intervention: { label: 'Interventions', formatStyle: 'string' },
 		casesAvertedTotal: { label: 'Total cases averted', formatStyle: 'decimal' },
-		totalCosts: { label: 'Total costs (USD)', formatStyle: 'currency' },
+		totalCost: { label: 'Total costs (USD)', formatStyle: 'currency' },
 		costPerCaseAverted: { label: 'Cost per case averted across 3 years (USD)', formatStyle: 'currency' }
 	};
 export const costTableColumns: ColumnDef<CostTableMetrics>[] = Object.entries(CostTableInfo).map(

--- a/src/lib/tables/costTable.ts
+++ b/src/lib/tables/costTable.ts
@@ -1,0 +1,62 @@
+import { renderComponent } from '$lib/components/ui/data-table';
+import type { ColumnDef } from '@tanstack/table-core';
+import DataTableSortHeader from '$lib/components/data-table/DataTableSortHeader.svelte';
+import type { Scenario } from '$lib/types/userState';
+import type { CasesAverted } from '$lib/process-results/processCases';
+import { ScenarioToLabel } from '$lib/charts/baseChart';
+
+export interface CostTableMetrics {
+	intervention: string;
+	casesAvertedTotal: number;
+	totalCosts: number;
+	costPerCaseAverted: number;
+}
+export const buildCostTableData = (
+	totalCosts: Partial<Record<Scenario, number>>,
+	casesAverted: Partial<Record<Scenario, CasesAverted>>,
+	population: number
+): CostTableMetrics[] => {
+	const scenarios = Object.keys(casesAverted) as Scenario[];
+
+	return scenarios
+		.filter((scenario) => casesAverted[scenario] && totalCosts[scenario]) // safety check
+		.map((scenario) => ({
+			intervention: ScenarioToLabel[scenario],
+			casesAvertedTotal: (casesAverted[scenario]!.totalAvertedCasesPer1000 / 1000) * population,
+			totalCosts: totalCosts[scenario]!,
+			costPerCaseAverted:
+				totalCosts[scenario]! / ((casesAverted[scenario]!.totalAvertedCasesPer1000 / 1000) * population)
+		}));
+};
+
+const CostTableInfo: Record<keyof CostTableMetrics, { label: string; formatStyle: 'string' | 'decimal' | 'currency' }> =
+	{
+		intervention: { label: 'Interventions', formatStyle: 'string' },
+		casesAvertedTotal: { label: 'Total cases averted', formatStyle: 'decimal' },
+		totalCosts: { label: 'Total costs (USD)', formatStyle: 'currency' },
+		costPerCaseAverted: { label: 'Cost per case averted across 3 years (USD)', formatStyle: 'currency' }
+	};
+export const costTableColumns: ColumnDef<CostTableMetrics>[] = Object.entries(CostTableInfo).map(
+	([key, headerInfo]) => ({
+		accessorKey: key,
+		cell: ({ getValue }) => {
+			const value = getValue() as string | number;
+
+			if (headerInfo.formatStyle === 'string') return value;
+
+			const formatter = new Intl.NumberFormat('en-US', {
+				style: headerInfo.formatStyle,
+				maximumFractionDigits: 1,
+				currency: 'USD',
+				notation: 'compact'
+			});
+			return formatter.format(value as number);
+		},
+		header: ({ column }) => {
+			return renderComponent(DataTableSortHeader, {
+				onclick: column.getToggleSortingHandler(),
+				label: headerInfo.label
+			});
+		}
+	})
+);

--- a/src/lib/tables/impactTable.ts
+++ b/src/lib/tables/impactTable.ts
@@ -47,7 +47,7 @@ export const buildImpactTableData = (
 		}
 	);
 };
-export const ImpactTableInfo: Record<
+const ImpactTableInfo: Record<
 	keyof ImpactTableMetrics,
 	{ label: string; formatStyle: 'string' | 'percent' | 'decimal' }
 > = {
@@ -95,7 +95,7 @@ export const impactTableColumns: ColumnDef<ImpactTableMetrics>[] = Object.entrie
 				maximumSignificantDigits: 3
 			});
 			const formattedValue = headerInfo.formatStyle === 'percent' ? (value as number) / 100 : (value as number);
-			return value !== undefined ? formatter.format(formattedValue) : 'N/A';
+			return formatter.format(formattedValue);
 		},
 		header: ({ column }) => {
 			return renderComponent(DataTableSortHeader, {

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -42,7 +42,7 @@
 				method: 'PATCH',
 				body: { formValues }
 			});
-		} catch (e) {
+		} catch (_e) {
 			toast.error('Failed to save form state');
 		}
 	};

--- a/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
+++ b/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { createHighchart } from '$lib/charts/baseChart';
 	import { getCostConfigs } from '$lib/charts/costsConfig';
+	import DataTable from '$lib/components/data-table/DataTable.svelte';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
 	import { DEFAULT_POPULATION, getTotalCostsPerScenario } from '$lib/process-results/costs';
 	import type { CasesAverted } from '$lib/process-results/processCases';
+	import { buildCostTableData, costTableColumns } from '$lib/tables/costTable';
 	import type { Scenario } from '$lib/types/userState';
 
 	interface Props {
@@ -19,6 +21,7 @@
 	let { costPer1000Config, costPerCaseConfig } = $derived(
 		getCostConfigs(totalCosts, casesAverted, Number(form.population) || DEFAULT_POPULATION)
 	);
+	let tableData = $derived(buildCostTableData(totalCosts, casesAverted, Number(form.population) || DEFAULT_POPULATION));
 </script>
 
 <div class="flex flex-col gap-6">
@@ -29,7 +32,7 @@
 	<section aria-label="Impact cases graph" class="rounded-lg border p-4">
 		<div {@attach createHighchart(costPerCaseConfig)} class={chartTheme}></div>
 	</section>
-	<!-- <section aria-label="Impact results table">
-			<DataTable columns={impactTableColumns} data={tableData} />
-		</section> -->
+	<section aria-label="Impact results table">
+		<DataTable columns={costTableColumns} data={tableData} />
+	</section>
 </div>

--- a/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
+++ b/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
@@ -1,22 +1,35 @@
 <script lang="ts">
+	import { createHighchart } from '$lib/charts/baseChart';
+	import { getCostPer1000Config } from '$lib/charts/costsConfig';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
-	import { getTotalCostsPerScenario } from '$lib/process-results/costs';
+	import { DEFAULT_POPULATION, getTotalCostsPerScenario } from '$lib/process-results/costs';
 	import type { CasesAverted } from '$lib/process-results/processCases';
 	import type { Scenario } from '$lib/types/userState';
 
 	interface Props {
 		form: Record<string, FormValue>;
 		casesAverted: Partial<Record<Scenario, CasesAverted>>;
+		chartTheme: string;
 	}
-	let { form, casesAverted }: Props = $props();
+	let { form, casesAverted, chartTheme }: Props = $props();
 
 	let totalCosts: Partial<Record<Scenario, number>> = $derived(
 		getTotalCostsPerScenario(Object.keys(casesAverted) as Scenario[], form)
 	);
+	let costPer1000Config = $derived(
+		getCostPer1000Config(totalCosts, casesAverted, (form.population as number) || DEFAULT_POPULATION)
+	);
 </script>
 
-<section aria-label="Cost results graph" class="rounded-lg border p-4">
-	<h3 class="mb-2 text-base font-semibold">Cost</h3>
-	<!-- TODO: tables + graphs -->
-	{JSON.stringify(totalCosts, null, 2)}
-</section>
+<div class="flex flex-col gap-6">
+	<section aria-label="Impact prevalence graph" class="rounded-lg border p-4">
+		<div {@attach createHighchart(costPer1000Config)} class={chartTheme}></div>
+	</section>
+
+	<!-- <section aria-label="Impact cases graph" class="rounded-lg border p-4">
+			<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
+		</section>
+		<section aria-label="Impact results table">
+			<DataTable columns={impactTableColumns} data={tableData} />
+		</section> -->
+</div>

--- a/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
+++ b/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { createHighchart } from '$lib/charts/baseChart';
-	import { getCostPer1000Config } from '$lib/charts/costsConfig';
+	import { getCostConfigs } from '$lib/charts/costsConfig';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
 	import { DEFAULT_POPULATION, getTotalCostsPerScenario } from '$lib/process-results/costs';
 	import type { CasesAverted } from '$lib/process-results/processCases';
@@ -16,8 +16,8 @@
 	let totalCosts: Partial<Record<Scenario, number>> = $derived(
 		getTotalCostsPerScenario(Object.keys(casesAverted) as Scenario[], form)
 	);
-	let costPer1000Config = $derived(
-		getCostPer1000Config(totalCosts, casesAverted, Number(form.population) || DEFAULT_POPULATION)
+	let { costPer1000Config, costPerCaseConfig } = $derived(
+		getCostConfigs(totalCosts, casesAverted, Number(form.population) || DEFAULT_POPULATION)
 	);
 </script>
 
@@ -26,10 +26,10 @@
 		<div {@attach createHighchart(costPer1000Config)} class={chartTheme}></div>
 	</section>
 
-	<!-- <section aria-label="Impact cases graph" class="rounded-lg border p-4">
-			<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
-		</section>
-		<section aria-label="Impact results table">
+	<section aria-label="Impact cases graph" class="rounded-lg border p-4">
+		<div {@attach createHighchart(costPerCaseConfig)} class={chartTheme}></div>
+	</section>
+	<!-- <section aria-label="Impact results table">
 			<DataTable columns={impactTableColumns} data={tableData} />
 		</section> -->
 </div>

--- a/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
+++ b/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
@@ -3,7 +3,11 @@
 	import { getCostConfigs } from '$lib/charts/costsConfig';
 	import DataTable from '$lib/components/data-table/DataTable.svelte';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
-	import { DEFAULT_POPULATION, getTotalCostsPerScenario } from '$lib/process-results/costs';
+	import {
+		DEFAULT_POPULATION,
+		combineCostsAndCasesAverted,
+		getTotalCostsPerScenario
+	} from '$lib/process-results/costs';
 	import type { CasesAverted } from '$lib/process-results/processCases';
 	import { buildCostTableData, costTableColumns } from '$lib/tables/costTable';
 	import type { Scenario } from '$lib/types/userState';
@@ -15,13 +19,14 @@
 	}
 	let { form, casesAverted, chartTheme }: Props = $props();
 
-	let totalCosts: Partial<Record<Scenario, number>> = $derived(
-		getTotalCostsPerScenario(Object.keys(casesAverted) as Scenario[], form)
+	let costsAndCasesAverted = $derived(
+		combineCostsAndCasesAverted(getTotalCostsPerScenario(Object.keys(casesAverted) as Scenario[], form), casesAverted)
 	);
+
 	let { costPer1000Config, costPerCaseConfig } = $derived(
-		getCostConfigs(totalCosts, casesAverted, Number(form.population) || DEFAULT_POPULATION)
+		getCostConfigs(costsAndCasesAverted, Number(form.population) || DEFAULT_POPULATION)
 	);
-	let tableData = $derived(buildCostTableData(totalCosts, casesAverted, Number(form.population) || DEFAULT_POPULATION));
+	let tableData = $derived(buildCostTableData(costsAndCasesAverted, Number(form.population) || DEFAULT_POPULATION));
 </script>
 
 <div class="flex flex-col gap-6">

--- a/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
+++ b/src/routes/projects/[project]/regions/[region]/_components/Cost.svelte
@@ -25,14 +25,14 @@
 </script>
 
 <div class="flex flex-col gap-6">
-	<section aria-label="Impact prevalence graph" class="rounded-lg border p-4">
+	<section aria-label="Cost per 1000 population graph" class="rounded-lg border p-4">
 		<div {@attach createHighchart(costPer1000Config)} class={chartTheme}></div>
 	</section>
 
-	<section aria-label="Impact cases graph" class="rounded-lg border p-4">
+	<section aria-label="Cost per case graph" class="rounded-lg border p-4">
 		<div {@attach createHighchart(costPerCaseConfig)} class={chartTheme}></div>
 	</section>
-	<section aria-label="Impact results table">
+	<section aria-label="Cost results table">
 		<DataTable columns={costTableColumns} data={tableData} />
 	</section>
 </div>

--- a/src/routes/projects/[project]/regions/[region]/_components/Impact.svelte
+++ b/src/routes/projects/[project]/regions/[region]/_components/Impact.svelte
@@ -6,19 +6,18 @@
 	import type { CasesAverted } from '$lib/process-results/processCases';
 	import { buildImpactTableData, impactTableColumns } from '$lib/tables/impactTable';
 	import type { CasesData, EmulatorResults, Scenario } from '$lib/types/userState';
-	import { mode } from 'mode-watcher';
 
 	interface Props {
 		casesAverted: Partial<Record<Scenario, CasesAverted>>;
 		emulatorResults: EmulatorResults;
 		postInterventionCasesMap: Record<Scenario, CasesData[]>;
+		chartTheme: string;
 	}
 
-	let { casesAverted, emulatorResults, postInterventionCasesMap }: Props = $props();
+	let { casesAverted, emulatorResults, postInterventionCasesMap, chartTheme }: Props = $props();
 	let prevalenceConfig = $derived(getPrevalenceConfig(emulatorResults.prevalence));
 	let casesConfig = $derived(getCasesConfig(casesAverted));
 	const tableData = $derived(buildImpactTableData(casesAverted, emulatorResults.prevalence, postInterventionCasesMap));
-	let chartTheme = $derived(mode.current === 'dark' ? 'highcharts-dark' : 'highcharts-light');
 </script>
 
 <div class="flex flex-col gap-6">

--- a/src/routes/projects/[project]/regions/[region]/_components/Results.svelte
+++ b/src/routes/projects/[project]/regions/[region]/_components/Results.svelte
@@ -33,6 +33,12 @@
 	</Tabs.Content>
 
 	<Tabs.Content value="cost">
-		<Cost {form} {casesAverted} {chartTheme} />
+		{#if Object.keys(casesAverted).length === 0}
+			<p class="p-4 text-center text-sm text-muted-foreground">
+				Cost results are not available because no interventions were selected.
+			</p>
+		{:else}
+			<Cost {form} {casesAverted} {chartTheme} />
+		{/if}
 	</Tabs.Content>
 </Tabs.Root>

--- a/src/routes/projects/[project]/regions/[region]/_components/Results.svelte
+++ b/src/routes/projects/[project]/regions/[region]/_components/Results.svelte
@@ -7,6 +7,7 @@
 	import type { EmulatorResults } from '$lib/types/userState';
 	import Cost from './Cost.svelte';
 	import Impact from './Impact.svelte';
+	import { mode } from 'mode-watcher';
 
 	interface Props {
 		emulatorResults: EmulatorResults;
@@ -15,6 +16,7 @@
 
 	let { emulatorResults, form }: Props = $props();
 	let tabSelected: 'impact' | 'cost' = $state('impact');
+	let chartTheme = $derived(mode.current === 'dark' ? 'highcharts-dark' : 'highcharts-light');
 
 	const postInterventionCasesMap = $derived(collectPostInterventionCases(emulatorResults.cases));
 	const casesAverted = $derived(
@@ -30,10 +32,10 @@
 		</Tabs.List>
 	</div>
 	<Tabs.Content value="impact">
-		<Impact {casesAverted} {emulatorResults} {postInterventionCasesMap} />
+		<Impact {chartTheme} {casesAverted} {emulatorResults} {postInterventionCasesMap} />
 	</Tabs.Content>
 
 	<Tabs.Content value="cost">
-		<Cost {form} {casesAverted} />
+		<Cost {form} {casesAverted} {chartTheme} />
 	</Tabs.Content>
 </Tabs.Root>


### PR DESCRIPTION
This PR is responsible for displaying cost data (2 graphs + 1 table). The graphs and table match what is in current [mint](https://mint-dev.dide.ic.ac.uk/) right now. Screenshots of charts can bee seen below.

Testing:
Run up app and play around with intervention + costs settings and see chart data and table data change and seem good.
<img width="1035" height="555" alt="image" src="https://github.com/user-attachments/assets/09c3c360-145a-4e37-b0aa-3b7736e8d66a" />
<img width="1035" height="555" alt="image" src="https://github.com/user-attachments/assets/a1afd4df-b6bd-47bb-b6b2-e72b26ba11f1" />
<img width="1035" height="555" alt="image" src="https://github.com/user-attachments/assets/2a7bdd59-8505-4f58-bedc-90f260833c52" />
