### PR TITLE
Mrc-6645 Strategise hook up with R

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"svelte-sonner": "^1.0.5",
 				"sveltekit-superforms": "^2.27.1",
 				"tailwind-merge": "^3.3.1",
-				"tailwind-variants": "^1.0.0",
+				"tailwind-variants": "^3.1.1",
 				"tailwindcss": "^4.0.0",
 				"tw-animate-css": "^1.3.6",
 				"typescript": "^5.0.0",
@@ -5392,31 +5392,23 @@
 			}
 		},
 		"node_modules/tailwind-variants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-1.0.0.tgz",
-			"integrity": "sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-3.1.1.tgz",
+			"integrity": "sha512-ftLXe3krnqkMHsuBTEmaVUXYovXtPyTK7ckEfDRXS8PBZx0bAUas+A0jYxuKA5b8qg++wvQ3d2MQ7l/xeZxbZQ==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"tailwind-merge": "3.0.2"
-			},
 			"engines": {
 				"node": ">=16.x",
 				"pnpm": ">=7.x"
 			},
 			"peerDependencies": {
+				"tailwind-merge": ">=3.0.0",
 				"tailwindcss": "*"
-			}
-		},
-		"node_modules/tailwind-variants/node_modules/tailwind-merge": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.0.2.tgz",
-			"integrity": "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/dcastil"
+			},
+			"peerDependenciesMeta": {
+				"tailwind-merge": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"svelte-sonner": "^1.0.5",
 		"sveltekit-superforms": "^2.27.1",
 		"tailwind-merge": "^3.3.1",
-		"tailwind-variants": "^1.0.0",
+		"tailwind-variants": "^3.1.1",
 		"tailwindcss": "^4.0.0",
 		"tw-animate-css": "^1.3.6",
 		"typescript": "^5.0.0",

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,7 +3,7 @@
 REGISTRY=ghcr.io
 ORG=mrc-ide
 API=mintr
-API_VERSION=mrc-6645-update-stragise # TODO: revert to main before merge
+API_VERSION=main
 NETWORK=mint_network
 NAME_REDIS=mint-redis
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,7 +3,7 @@
 REGISTRY=ghcr.io
 ORG=mrc-ide
 API=mintr
-API_VERSION=main
+API_VERSION=mrc-6645-update-stragise # TODO: revert to main before merge
 NETWORK=mint_network
 NAME_REDIS=mint-redis
 

--- a/src/lib/charts/baseChart.ts
+++ b/src/lib/charts/baseChart.ts
@@ -22,15 +22,14 @@ export const configureHighcharts = () => {
 					useHTML: true,
 					theme: {
 						fill: 'var(--background)',
-						stroke: 'var(--muted-foreground)',
+						// @ts-expect-error: typeExportingButtonsOptionsObject missing r, states properties
 						r: 3,
 						states: {
 							hover: {
 								fill: 'var(--accent)'
 							},
 							select: {
-								fill: 'var(--accent)',
-								stroke: 'var(--foreground)'
+								fill: 'var(--accent)'
 							}
 						}
 					}

--- a/src/lib/components/Loader.svelte
+++ b/src/lib/components/Loader.svelte
@@ -1,0 +1,6 @@
+<div class="flex items-center justify-center p-8">
+	<div class="flex flex-col items-center gap-3">
+		<div class="h-8 w-8 animate-spin rounded-full border-2 border-muted border-t-primary"></div>
+		<div class="text-sm text-muted-foreground">Running...</div>
+	</div>
+</div>

--- a/src/lib/components/ui/alert/alert-description.svelte
+++ b/src/lib/components/ui/alert/alert-description.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-description"
+	class={cn(
+		"text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert/alert-description.svelte
+++ b/src/lib/components/ui/alert/alert-description.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { HTMLAttributes } from "svelte/elements";
-	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="alert-description"
 	class={cn(
-		"text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+		'col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/alert/alert-title.svelte
+++ b/src/lib/components/ui/alert/alert-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-title"
+	class={cn("col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert/alert-title.svelte
+++ b/src/lib/components/ui/alert/alert-title.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { HTMLAttributes } from "svelte/elements";
-	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="alert-title"
-	class={cn("col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight", className)}
+	class={cn('col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/src/lib/components/ui/alert/alert.svelte
+++ b/src/lib/components/ui/alert/alert.svelte
@@ -1,0 +1,39 @@
+<script lang="ts" module>
+	import { type VariantProps, tv } from 'tailwind-variants';
+
+	export const alertVariants = tv({
+		base: 'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+		variants: {
+			variant: {
+				default: 'bg-card text-card-foreground',
+				destructive:
+					'text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
+				warning: 'text-amber-500 bg-card *:data-[slot=alert-description]:text-amber-500/80 [&>svg]:text-current'
+			}
+		},
+		defaultVariants: {
+			variant: 'default'
+		}
+	});
+
+	export type AlertVariant = VariantProps<typeof alertVariants>['variant'];
+</script>
+
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = 'default',
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		variant?: AlertVariant;
+	} = $props();
+</script>
+
+<div bind:this={ref} data-slot="alert" class={cn(alertVariants({ variant }), className)} {...restProps} role="alert">
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert/alert.svelte
+++ b/src/lib/components/ui/alert/alert.svelte
@@ -8,7 +8,8 @@
 				default: 'bg-card text-card-foreground',
 				destructive:
 					'text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
-				warning: 'text-amber-500 bg-card *:data-[slot=alert-description]:text-amber-500/80 [&>svg]:text-current'
+				warning:
+					'text-amber-600 dark:text-amber-400 bg-card *:data-[slot=alert-description]:text-amber-600/80 dark:*:data-[slot=alert-description]:text-amber-400/80 [&>svg]:text-current'
 			}
 		},
 		defaultVariants: {

--- a/src/lib/components/ui/alert/index.ts
+++ b/src/lib/components/ui/alert/index.ts
@@ -1,0 +1,14 @@
+import Root from "./alert.svelte";
+import Description from "./alert-description.svelte";
+import Title from "./alert-title.svelte";
+export { alertVariants, type AlertVariant } from "./alert.svelte";
+
+export {
+	Root,
+	Description,
+	Title,
+	//
+	Root as Alert,
+	Description as AlertDescription,
+	Title as AlertTitle,
+};

--- a/src/lib/components/ui/alert/index.ts
+++ b/src/lib/components/ui/alert/index.ts
@@ -1,7 +1,7 @@
-import Root from "./alert.svelte";
-import Description from "./alert-description.svelte";
-import Title from "./alert-title.svelte";
-export { alertVariants, type AlertVariant } from "./alert.svelte";
+import Root from './alert.svelte';
+import Description from './alert-description.svelte';
+import Title from './alert-title.svelte';
+export { alertVariants, type AlertVariant } from './alert.svelte';
 
 export {
 	Root,
@@ -10,5 +10,5 @@ export {
 	//
 	Root as Alert,
 	Description as AlertDescription,
-	Title as AlertTitle,
+	Title as AlertTitle
 };

--- a/src/lib/server/region.ts
+++ b/src/lib/server/region.ts
@@ -73,7 +73,7 @@ export const getValidatedRegionData = (userState: UserState, projectName: string
 
 	return regionData;
 };
-export const getValidatedProjectData = (userState: UserState, projectName: string) => {
+export const getValidatedProjectData = (userState: UserState, projectName?: string) => {
 	const projectData = userState.projects.find((p) => p.name === projectName);
 	if (!projectData) error(404, `Project "${projectName}" not found`);
 	return projectData;

--- a/src/lib/server/region.ts
+++ b/src/lib/server/region.ts
@@ -47,7 +47,7 @@ export const saveRegionRun = async (
 	formValues: Record<string, FormValue>,
 	cases: CasesData[]
 ) => {
-	const regionData = getValidatedRegionData(userState, project, region);
+	const regionData = getRegionFromUserState(userState, project, region);
 	regionData.formValues = formValues;
 	regionData.cases = cases;
 	regionData.hasRunBaseline = true;
@@ -60,20 +60,20 @@ export const saveRegionFormState = async (
 	regionName: string,
 	formValues: Record<string, FormValue>
 ) => {
-	const regionData = getValidatedRegionData(userState, projectName, regionName);
+	const regionData = getRegionFromUserState(userState, projectName, regionName);
 	regionData.formValues = formValues;
 	await saveUserState(userState);
 };
 
-export const getValidatedRegionData = (userState: UserState, projectName: string, regionName: string): Region => {
-	const projectData = getValidatedProjectData(userState, projectName);
+export const getRegionFromUserState = (userState: UserState, projectName: string, regionName: string): Region => {
+	const projectData = getProjectFromUserState(userState, projectName);
 
 	const regionData = projectData.regions.find((r) => r.name === regionName);
 	if (!regionData) error(404, `Region "${regionName}" not found in project "${projectName}"`);
 
 	return regionData;
 };
-export const getValidatedProjectData = (userState: UserState, projectName?: string) => {
+export const getProjectFromUserState = (userState: UserState, projectName?: string) => {
 	const projectData = userState.projects.find((p) => p.name === projectName);
 	if (!projectData) error(404, `Project "${projectName}" not found`);
 	return projectData;

--- a/src/lib/types/userState.ts
+++ b/src/lib/types/userState.ts
@@ -33,12 +33,15 @@ export interface Region {
 	name: string;
 	hasRunBaseline: boolean;
 	formValues: Record<string, FormValue>;
+	cases: CasesData[];
+}
+export interface Strategy {
+	budget: number;
 }
 export interface Project {
 	name: string;
-	budget: number;
 	regions: Region[];
-	canStrategize?: boolean;
+	strategy: Strategy;
 }
 
 export interface UserState {

--- a/src/lib/types/userState.ts
+++ b/src/lib/types/userState.ts
@@ -35,8 +35,19 @@ export interface Region {
 	formValues: Record<string, FormValue>;
 	cases: CasesData[];
 }
+export interface StrategiseIntervention {
+	region: string;
+	intervention: Scenario;
+	cost: number;
+	casesAverted: number;
+}
+export interface StrategiseResults {
+	costThreshold: number;
+	interventions: StrategiseIntervention[];
+}
 export interface Strategy {
 	budget: number;
+	results?: StrategiseResults[];
 }
 export interface Project {
 	name: string;

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -3,3 +3,4 @@ import { PUBLIC_MINTR_URL } from '$env/static/public';
 export const regionUrl = (projectName: string, regionName: string) => `/projects/${projectName}/regions/${regionName}`;
 export const regionFormUrl = () => PUBLIC_MINTR_URL + '/options';
 export const runEmulatorUrl = () => PUBLIC_MINTR_URL + '/emulator/run';
+export const strategiseUrl = () => PUBLIC_MINTR_URL + '/strategise';

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -33,10 +33,12 @@ export const actions: Actions = {
 			regions: form.data.regions.map((region) => ({
 				name: region,
 				formValues: {},
-				hasRunBaseline: false
+				hasRunBaseline: false,
+				cases: []
 			})),
-			budget: 2000000, // default budget (TODO: place somewhere better with other defaults)
-			canStrategize: false
+			strategy: {
+				budget: 200000
+			}
 		});
 
 		return { form };

--- a/src/routes/_components/Header.svelte
+++ b/src/routes/_components/Header.svelte
@@ -5,7 +5,7 @@
 	import MoonIcon from '@lucide/svelte/icons/moon';
 	import SunIcon from '@lucide/svelte/icons/sun';
 	import { toggleMode } from 'mode-watcher';
-	import HeaderRegionsDropdown from '../projects/[project]/regions/[region]/_components/HeaderRegionsDropdown.svelte';
+	import HeaderRegionsDropdown from './HeaderRegionsDropdown.svelte';
 	import type { UserState } from '$lib/types/userState';
 
 	interface Props {

--- a/src/routes/_components/Header.svelte
+++ b/src/routes/_components/Header.svelte
@@ -25,10 +25,10 @@
 			class="ml-2 flex items-center justify-center px-2 text-xl font-extrabold text-primary hover:text-primary/80"
 			><img src={logo} alt="MINT logo" class="h-12 w-12" />MINT</a
 		>
-		{#if project && region}
+		{#if project}
 			<HeaderRegionsDropdown {project} {region} />
 		{/if}
-		{#if project && region}
+		{#if project}
 			<a class={buttonVariants({ variant: 'link', class: 'p-1' })} href={`/projects/${project.name}/strategise`}>
 				Strategise across regions
 			</a>

--- a/src/routes/_components/Header.svelte
+++ b/src/routes/_components/Header.svelte
@@ -28,9 +28,9 @@
 		{#if project && region}
 			<HeaderRegionsDropdown {project} {region} />
 		{/if}
-		{#if project && project.canStrategize}
-			<a class={buttonVariants({ variant: 'link', class: 'p-1' })} href={`/projects/${project.name}/strategize`}>
-				Strategize across regions
+		{#if project && region}
+			<a class={buttonVariants({ variant: 'link', class: 'p-1' })} href={`/projects/${project.name}/strategise`}>
+				Strategise across regions
 			</a>
 		{/if}
 		<div class="ml-auto flex items-center gap-3 px-4">

--- a/src/routes/_components/HeaderRegionsDropdown.svelte
+++ b/src/routes/_components/HeaderRegionsDropdown.svelte
@@ -11,7 +11,7 @@
 	import Plus from '@lucide/svelte/icons/plus';
 	import { superForm } from 'sveltekit-superforms';
 	import { zodClient } from 'sveltekit-superforms/adapters';
-	import { addRegionSchema } from '../schema';
+	import { addRegionSchema } from '../projects/[project]/regions/[region]/schema';
 
 	interface Props {
 		region: Region;

--- a/src/routes/_components/HeaderRegionsDropdown.svelte
+++ b/src/routes/_components/HeaderRegionsDropdown.svelte
@@ -14,7 +14,7 @@
 	import { addRegionSchema } from '../projects/[project]/regions/[region]/schema';
 
 	interface Props {
-		region: Region;
+		region?: Region;
 		project: Project;
 	}
 
@@ -35,7 +35,13 @@
 <DropdownMenu.Root bind:open={isOpen}>
 	<DropdownMenu.Trigger>
 		{#snippet child({ props })}
-			<Button {...props} variant="ghost" size="sm">{project.name}: {region.name} <ChevronsUpDownIcon /></Button>
+			<Button {...props} variant="ghost" size="sm">
+				{project.name}
+				{#if region}
+					- {region.name}
+				{/if}
+				<ChevronsUpDownIcon /></Button
+			>
 		{/snippet}
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content class="max-w-64">
@@ -46,7 +52,7 @@
 		{/each}
 		<DropdownMenu.Separator />
 		<DropdownMenu.Sub>
-			<form class="flex flex-col gap-1" method="POST" action="?/addRegion" use:enhance>
+			<form class="flex flex-col gap-1" method="POST" action={`/projects/${project.name}?/addRegion`} use:enhance>
 				<Label for="name" class="mx-1 my-2">Add Region</Label>
 				<div class="flex gap-1.5">
 					<Form.Field {form} name="name">

--- a/src/routes/projects/[project]/+page.server.ts
+++ b/src/routes/projects/[project]/+page.server.ts
@@ -1,0 +1,34 @@
+import { regionUrl } from '$lib/url';
+import { addRegionSchema } from '$routes/projects/[project]/regions/[region]/schema';
+import { redirect, type Actions } from '@sveltejs/kit';
+import { fail, setError, superValidate } from 'sveltekit-superforms';
+import { zod } from 'sveltekit-superforms/adapters';
+
+export const actions: Actions = {
+	addRegion: async ({ request, params, locals }) => {
+		const { project } = params;
+		const addRegionForm = await superValidate(request, zod(addRegionSchema));
+
+		const projectData = locals.userState.projects.find((p) => p.name === project);
+		if (!projectData) {
+			return fail(404, { addRegionForm, error: `Project "${project}" not found` });
+		}
+
+		const isRegionDuplicate = projectData.regions.some((r) => r.name === addRegionForm.data.name);
+		if (isRegionDuplicate) {
+			setError(addRegionForm, 'name', 'Region names must be unique');
+		}
+		if (!addRegionForm.valid) {
+			return fail(400, { addRegionForm });
+		}
+
+		projectData.regions.push({
+			name: addRegionForm.data.name,
+			formValues: {},
+			hasRunBaseline: false,
+			cases: []
+		});
+
+		return redirect(303, regionUrl(projectData.name, addRegionForm.data.name));
+	}
+};

--- a/src/routes/projects/[project]/regions/[region]/+page.server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+page.server.ts
@@ -41,7 +41,8 @@ export const actions: Actions = {
 		projectData.regions.push({
 			name: addRegionForm.data.name,
 			formValues: {},
-			hasRunBaseline: false
+			hasRunBaseline: false,
+			cases: []
 		});
 
 		return redirect(303, regionUrl(projectData.name, addRegionForm.data.name));

--- a/src/routes/projects/[project]/regions/[region]/+page.server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+page.server.ts
@@ -1,4 +1,4 @@
-import { getRegionFormSchema, getValidatedRegionData, runEmulatorOnLoad } from '$lib/server/region';
+import { getRegionFormSchema, getRegionFromUserState, runEmulatorOnLoad } from '$lib/server/region';
 import { addRegionSchema } from '$routes/projects/[project]/regions/[region]/schema';
 import { superValidate } from 'sveltekit-superforms';
 import { zod } from 'sveltekit-superforms/adapters';
@@ -9,7 +9,7 @@ export const load: PageServerLoad = async ({ params, locals, fetch }) => {
 	const addRegionForm = await superValidate(zod(addRegionSchema));
 
 	const userState = locals.userState;
-	const regionData = getValidatedRegionData(userState, project, region);
+	const regionData = getRegionFromUserState(userState, project, region);
 
 	return {
 		formSchema: await getRegionFormSchema(project, region, fetch),

--- a/src/routes/projects/[project]/regions/[region]/+page.server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+page.server.ts
@@ -1,8 +1,6 @@
 import { getRegionFormSchema, getValidatedRegionData, runEmulatorOnLoad } from '$lib/server/region';
-import { regionUrl } from '$lib/url';
 import { addRegionSchema } from '$routes/projects/[project]/regions/[region]/schema';
-import { redirect, type Actions } from '@sveltejs/kit';
-import { fail, setError, superValidate } from 'sveltekit-superforms';
+import { superValidate } from 'sveltekit-superforms';
 import { zod } from 'sveltekit-superforms/adapters';
 import type { PageServerLoad } from './$types';
 
@@ -19,32 +17,4 @@ export const load: PageServerLoad = async ({ params, locals, fetch }) => {
 		addRegionForm,
 		runPromise: runEmulatorOnLoad(regionData, fetch) // stream as it resolves
 	};
-};
-export const actions: Actions = {
-	addRegion: async ({ request, params, locals }) => {
-		const { project } = params;
-		const addRegionForm = await superValidate(request, zod(addRegionSchema));
-
-		const projectData = locals.userState.projects.find((p) => p.name === project);
-		if (!projectData) {
-			return fail(404, { addRegionForm, error: `Project "${project}" not found` });
-		}
-
-		const isRegionDuplicate = projectData.regions.some((r) => r.name === addRegionForm.data.name);
-		if (isRegionDuplicate) {
-			setError(addRegionForm, 'name', 'Region names must be unique');
-		}
-		if (!addRegionForm.valid) {
-			return fail(400, { addRegionForm });
-		}
-
-		projectData.regions.push({
-			name: addRegionForm.data.name,
-			formValues: {},
-			hasRunBaseline: false,
-			cases: []
-		});
-
-		return redirect(303, regionUrl(projectData.name, addRegionForm.data.name));
-	}
 };

--- a/src/routes/projects/[project]/regions/[region]/+page.svelte
+++ b/src/routes/projects/[project]/regions/[region]/+page.svelte
@@ -8,6 +8,7 @@
 	import { toast } from 'svelte-sonner';
 	import type { PageProps } from './$types';
 	import Results from './_components/Results.svelte';
+	import Loader from '$lib/components/Loader.svelte';
 	let { data, params }: PageProps = $props();
 
 	let isRunning = $state(false);
@@ -68,12 +69,7 @@
 		submitText="Run baseline"
 	>
 		{#await runPromise}
-			<div class="flex items-center justify-center p-8">
-				<div class="flex flex-col items-center gap-3">
-					<div class="h-8 w-8 animate-spin rounded-full border-2 border-muted border-t-primary"></div>
-					<div class="text-sm text-muted-foreground">Running...</div>
-				</div>
-			</div>
+			<Loader />
 		{:then emulatorResults}
 			{#if emulatorResults}
 				<Results {emulatorResults} {form} bind:activeTab />

--- a/src/routes/projects/[project]/regions/[region]/+server.ts
+++ b/src/routes/projects/[project]/regions/[region]/+server.ts
@@ -1,5 +1,5 @@
 import { ApiError, apiFetch } from '$lib/fetch';
-import { saveRegionFormState } from '$lib/server/region';
+import { saveRegionFormState, saveRegionRun } from '$lib/server/region';
 import type { EmulatorResults } from '$lib/types/userState';
 import { runEmulatorUrl } from '$lib/url';
 import { error, json } from '@sveltejs/kit';
@@ -22,7 +22,7 @@ export const POST: RequestHandler = async ({ request, locals, params, fetch }) =
 			fetcher: fetch
 		});
 
-		await saveRegionFormState(locals.userState, project, region, formValues);
+		await saveRegionRun(locals.userState, project, region, formValues, res.data.cases);
 		return json(res);
 	} catch (e) {
 		const status = e instanceof ApiError ? e.status : 500;

--- a/src/routes/projects/[project]/strategise/+page.server.ts
+++ b/src/routes/projects/[project]/strategise/+page.server.ts
@@ -1,5 +1,5 @@
 import { ApiError, apiFetch } from '$lib/fetch';
-import { getValidatedProjectData } from '$lib/server/region';
+import { getProjectFromUserState } from '$lib/server/region';
 import type { StrategiseResults } from '$lib/types/userState';
 import { strategiseUrl } from '$lib/url';
 import { message, superValidate, type ErrorStatus } from 'sveltekit-superforms';
@@ -11,7 +11,7 @@ import { getCasesAvertedAndCostsForStrategise } from './utils';
 export const load: PageServerLoad = async ({ params, locals }) => {
 	const { project } = params;
 
-	const projectData = getValidatedProjectData(locals.userState, project);
+	const projectData = getProjectFromUserState(locals.userState, project);
 	const regionalStrategies = getCasesAvertedAndCostsForStrategise(projectData.regions);
 
 	return {
@@ -29,7 +29,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 export const actions: Actions = {
 	default: async ({ request, locals, fetch, params }) => {
 		const { project } = params;
-		const projectData = getValidatedProjectData(locals.userState, project);
+		const projectData = getProjectFromUserState(locals.userState, project);
 		const form = await superValidate(request, zod(strategiseSchema));
 		if (!form.valid) {
 			return { form };

--- a/src/routes/projects/[project]/strategise/+page.server.ts
+++ b/src/routes/projects/[project]/strategise/+page.server.ts
@@ -1,0 +1,30 @@
+import { getValidatedProjectData } from '$lib/server/region';
+import { superValidate } from 'sveltekit-superforms';
+import type { PageServerLoad } from './$types';
+import { zod } from 'sveltekit-superforms/adapters';
+import { strategiseSchema } from './schema';
+import type { Actions } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params, locals }) => {
+	const { project } = params;
+
+	const projectData = getValidatedProjectData(locals.userState, project);
+
+	return {
+		project: projectData,
+		form: await superValidate({ budget: projectData.strategy.budget }, zod(strategiseSchema))
+	};
+};
+
+export const actions: Actions = {
+	default: async ({ request, locals }) => {
+		const form = await superValidate(request, zod(strategiseSchema));
+		if (!form.valid) {
+			return { form };
+		}
+		console.log(form.data);
+		// todo: get strategy results and save to user data
+
+		return { form };
+	}
+};

--- a/src/routes/projects/[project]/strategise/+page.server.ts
+++ b/src/routes/projects/[project]/strategise/+page.server.ts
@@ -29,6 +29,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 export const actions: Actions = {
 	default: async ({ request, locals, fetch, params }) => {
 		const { project } = params;
+		const projectData = getValidatedProjectData(locals.userState, project);
 		const form = await superValidate(request, zod(strategiseSchema));
 		if (!form.valid) {
 			return { form };
@@ -44,22 +45,17 @@ export const actions: Actions = {
 					regions: form.data.regionalStrategies
 				}
 			});
-			console.log(
-				JSON.stringify({
-					budget: form.data.budget,
-					regions: form.data.regionalStrategies
-				})
-			);
+
 			// save results to user state
-			const projectData = getValidatedProjectData(locals.userState, project);
 			projectData.strategy = {
 				budget: form.data.budget,
 				results: res.data
 			};
-			return { form };
 		} catch (e) {
 			const status = (e instanceof ApiError ? e.status : 500) as ErrorStatus;
 			return message(form, 'Failed to run strategise', { status });
 		}
+
+		return { form };
 	}
 };

--- a/src/routes/projects/[project]/strategise/+page.svelte
+++ b/src/routes/projects/[project]/strategise/+page.svelte
@@ -29,8 +29,8 @@
 	<div class="mb-6">
 		<h1 class="text-2xl font-bold">Strategise across regions for {data.project.name}</h1>
 		<p class="mb-1 leading-relaxed text-muted-foreground">
-			This tool can investigate how different interventions could be distributed across wider regions to minimise the
-			overall number of malaria cases whilst achieving local goals.
+			This tool can investigate how different interventions could be distributed across all project regions given a
+			total budget, to minimise the overall number of malaria cases whilst achieving local goals.
 		</p>
 		<p class="mb-1 leading-relaxed text-muted-foreground">
 			The regions must have run with interventions to be included in the strategise tool.

--- a/src/routes/projects/[project]/strategise/+page.svelte
+++ b/src/routes/projects/[project]/strategise/+page.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
+	import Loader from '$lib/components/Loader.svelte';
 	import * as Alert from '$lib/components/ui/alert/index';
 	import * as Form from '$lib/components/ui/form';
 	import { Input } from '$lib/components/ui/input';
 	import CircleAlert from '@lucide/svelte/icons/circle-alert';
+	import { toast } from 'svelte-sonner';
 	import { superForm } from 'sveltekit-superforms';
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import type { PageProps } from './$types';
 	import { strategiseSchema } from './schema';
-	import Loader from '$lib/components/Loader.svelte';
-	import { toast } from 'svelte-sonner';
 	let { data }: PageProps = $props();
 
 	const form = superForm(data.form, {
@@ -21,10 +21,7 @@
 			}
 		}
 	});
-	const { form: formData, enhance, delayed, message } = form;
-
-	$inspect(data.project.strategy.results, 'results');
-	$inspect($formData.regionalStrategies, 'strategies');
+	const { form: formData, enhance, delayed } = form;
 </script>
 
 <div class="mx-auto max-w-7xl px-4 py-8">

--- a/src/routes/projects/[project]/strategise/+page.svelte
+++ b/src/routes/projects/[project]/strategise/+page.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import * as Alert from '$lib/components/ui/alert/index';
+	import * as Form from '$lib/components/ui/form';
+	import { Input } from '$lib/components/ui/input';
+	import {
+		collectPostInterventionCases,
+		convertPer1000ToTotal,
+		getAvertedCasesData,
+		type CasesAverted
+	} from '$lib/process-results/processCases';
+	import CircleAlert from '@lucide/svelte/icons/circle-alert';
+	import { superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import type { PageProps } from './$types';
+	import { strategiseSchema, type StrategiseRegions } from './schema';
+	import type { Scenario } from '$lib/types/userState';
+	import { z } from 'zod';
+	import {
+		combineCostsAndCasesAverted,
+		DEFAULT_POPULATION,
+		getTotalCostsPerScenario
+	} from '$lib/process-results/costs';
+
+	let { data }: PageProps = $props();
+
+	const form = superForm(data.form, {
+		validators: zodClient(strategiseSchema),
+		resetForm: false,
+		dataType: 'json'
+	});
+	const { form: formData, enhance } = form;
+
+	const allCasesAvertedData = $derived.by(() => {
+		const allCasesAvertedData: Record<string, Partial<Record<Scenario, CasesAverted>>> = {};
+
+		for (const region of data.project.regions) {
+			const postInterventionCases = collectPostInterventionCases(region.cases);
+			const casesAverted = getAvertedCasesData(postInterventionCases);
+			if (Object.keys(casesAverted).length > 0) {
+				allCasesAvertedData[region.name] = casesAverted;
+			}
+		}
+
+		return allCasesAvertedData;
+	});
+
+	let casesAvertedAndCostsPerRegion: StrategiseRegions = $derived.by(() => {
+		const result: StrategiseRegions = [];
+		for (const [region, casesAvertedForRegion] of Object.entries(allCasesAvertedData)) {
+			const regionForm = data.project.regions.find((r) => r.name === region)?.formValues ?? {};
+			const costsAndCasesAverted = combineCostsAndCasesAverted(
+				getTotalCostsPerScenario(Object.keys(casesAvertedForRegion) as Scenario[], regionForm),
+				casesAvertedForRegion
+			);
+
+			const interventions: StrategiseRegions[number]['interventions'] = [];
+			for (const [scenario, { casesAverted, totalCost }] of Object.entries(costsAndCasesAverted)) {
+				interventions.push({
+					intervention: scenario,
+					cost: totalCost,
+					casesAverted: convertPer1000ToTotal(
+						casesAverted.totalAvertedCasesPer1000,
+						Number(regionForm.population) || DEFAULT_POPULATION
+					)
+				});
+			}
+			result.push({
+				region,
+				interventions
+			});
+		}
+
+		return result;
+	});
+
+	$inspect(casesAvertedAndCostsPerRegion);
+</script>
+
+<div class="mx-auto max-w-7xl px-4 py-8">
+	<div class="mb-6">
+		<h1 class="text-2xl font-bold">Strategise across regions for {data.project.name}</h1>
+		<p class="mb-1 leading-relaxed text-muted-foreground">
+			This tool can investigate how different interventions could be distributed across wider regions to minimise the
+			overall number of malaria cases whilst achieving local goals.
+		</p>
+		<p class="mb-1 leading-relaxed text-muted-foreground">
+			The regions must have run with interventions to be included in the strategise tool.
+		</p>
+	</div>
+	{#if Object.keys(allCasesAvertedData).length > 1}
+		<form method="POST" use:enhance>
+			<div class="flex space-x-3">
+				<Form.Field {form} name="budget">
+					<Form.Control>
+						{#snippet children({ props })}
+							<div class="flex space-x-2">
+								<Form.Label class="whitespace-nowrap" for="budget">Total available budget</Form.Label>
+								<Input type="number" step={100} {...props} placeholder="Enter budget" bind:value={$formData.budget} />
+							</div>
+						{/snippet}
+					</Form.Control>
+					<Form.Description
+						>The total budget available to distribute across all regions over the 3-year period.</Form.Description
+					>
+					<Form.FieldErrors />
+				</Form.Field>
+				<Form.Button>Strategise</Form.Button>
+			</div>
+		</form>
+	{:else}
+		<Alert.Root variant="warning">
+			<CircleAlert />
+			<Alert.Title>Strategise Tool Unavailable</Alert.Title>
+			<Alert.Description
+				>At least two regions must have run with interventions to use the strategise tool.</Alert.Description
+			>
+		</Alert.Root>
+	{/if}
+</div>

--- a/src/routes/projects/[project]/strategise/+page.svelte
+++ b/src/routes/projects/[project]/strategise/+page.svelte
@@ -9,6 +9,7 @@
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import type { PageProps } from './$types';
 	import { strategiseSchema } from './schema';
+	import StrategiseResults from './StrategiseResults.svelte';
 	let { data }: PageProps = $props();
 
 	const form = superForm(data.form, {
@@ -36,14 +37,21 @@
 		</p>
 	</div>
 	{#if $formData.regionalStrategies.length > 1}
-		<form method="POST" use:enhance>
+		<form method="POST" use:enhance novalidate>
 			<div class="flex space-x-3">
 				<Form.Field {form} name="budget">
 					<Form.Control>
 						{#snippet children({ props })}
 							<div class="flex space-x-2">
 								<Form.Label class="whitespace-nowrap" for="budget">Total available budget</Form.Label>
-								<Input type="number" step={100} {...props} placeholder="Enter budget" bind:value={$formData.budget} />
+								<Input
+									type="number"
+									min={0}
+									step={100}
+									{...props}
+									placeholder="Enter budget"
+									bind:value={$formData.budget}
+								/>
 							</div>
 						{/snippet}
 					</Form.Control>
@@ -60,7 +68,7 @@
 		{/if}
 
 		{#if data.project.strategy.results}
-			{JSON.stringify(data.project.strategy.results)}
+			<StrategiseResults strategiseResults={data.project.strategy.results} />
 		{/if}
 	{:else}
 		<Alert.Root variant="warning">

--- a/src/routes/projects/[project]/strategise/StrategiseResults.svelte
+++ b/src/routes/projects/[project]/strategise/StrategiseResults.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { StrategiseResults } from '$lib/types/userState';
+
+	interface Props {
+		strategiseResults: StrategiseResults[];
+	}
+	let { strategiseResults }: Props = $props();
+</script>
+
+<!-- TODO: add table + graphs -->
+<pre>
+    {JSON.stringify(strategiseResults, null, 1)}
+</pre>

--- a/src/routes/projects/[project]/strategise/schema.ts
+++ b/src/routes/projects/[project]/strategise/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 export const strategiseSchema = z.object({
-	budget: z.number().min(1, 'Budget must greater than 0'),
+	budget: z.number().min(1, 'Budget must be greater than 0'),
 	regionalStrategies: z
 		.object({
 			region: z.string(),

--- a/src/routes/projects/[project]/strategise/schema.ts
+++ b/src/routes/projects/[project]/strategise/schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+export const strategiseSchema = z.object({
+	budget: z.number().min(1, 'Budget must greater than 0'),
+	regions: z
+		.object({
+			region: z.string(),
+			interventions: z
+				.object({
+					intervention: z.string(),
+					cost: z.number().min(0, 'Cost must be 0 or greater'),
+					casesAverted: z.number()
+				})
+				.array()
+				.min(1, 'Select at least one intervention')
+		})
+		.array()
+});
+
+// type for region
+export type StrategiseRegions = z.infer<typeof strategiseSchema>['regions'];

--- a/src/routes/projects/[project]/strategise/schema.ts
+++ b/src/routes/projects/[project]/strategise/schema.ts
@@ -16,5 +16,4 @@ export const strategiseSchema = z.object({
 		.array()
 });
 
-// type for region
 export type StrategiseRegions = z.infer<typeof strategiseSchema>['regionalStrategies'];

--- a/src/routes/projects/[project]/strategise/schema.ts
+++ b/src/routes/projects/[project]/strategise/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 export const strategiseSchema = z.object({
 	budget: z.number().min(1, 'Budget must greater than 0'),
-	regions: z
+	regionalStrategies: z
 		.object({
 			region: z.string(),
 			interventions: z
@@ -17,4 +17,4 @@ export const strategiseSchema = z.object({
 });
 
 // type for region
-export type StrategiseRegions = z.infer<typeof strategiseSchema>['regions'];
+export type StrategiseRegions = z.infer<typeof strategiseSchema>['regionalStrategies'];

--- a/src/routes/projects/[project]/strategise/utils.ts
+++ b/src/routes/projects/[project]/strategise/utils.ts
@@ -9,10 +9,24 @@ import {
 import type { Region, Scenario } from '$lib/types/userState';
 import type { StrategiseRegions } from './schema';
 
+/**
+ * Processes a collection of regions to extract cases averted and cost data for strategy analysis.
+ * Filters out regions that don't have valid cases averted data.
+ *
+ * @param regions - Array of regions
+ * @returns Array of processed region data with intervention analysis, excluding regions with no valid data
+ */
 export const getCasesAvertedAndCostsForStrategise = (regions: Region[]): StrategiseRegions => {
 	return regions.map(processRegionData).filter((region) => region !== null);
 };
 
+/**
+ * Processes a single region to extract and structure intervention analysis data.
+ * Combines cases averted data with cost information and population from form data.
+ *
+ * @param region - Individual region containing cases data and form values
+ * @returns Structured region data with interventions analysis, or null if no valid cases averted data exists
+ */
 const processRegionData = (region: Region) => {
 	const casesAverted = extractCasesAvertedData(region);
 	if (!casesAverted || Object.keys(casesAverted).length === 0) {
@@ -27,11 +41,26 @@ const processRegionData = (region: Region) => {
 	};
 };
 
+/**
+ * Extracts cases averted data from a region's  cases.
+ * Processes post-intervention cases to calculate how many cases were prevented by interventions.
+ *
+ * @param region - Region containing raw cases data
+ * @returns Partial record mapping scenarios to their respective cases averted data
+ */
 const extractCasesAvertedData = (region: Region) => {
 	const postInterventionCases = collectPostInterventionCases(region.cases);
 	return getAvertedCasesData(postInterventionCases);
 };
 
+/**
+ * Builds intervention analysis data by combining cases averted with cost calculations.
+ * Converts per-1000 population metrics to total numbers based on region population.
+ *
+ * @param casesAvertedData - Mapping of scenarios to their cases averted statistics
+ * @param regionForm - Form values containing cost parameters and population data
+ * @returns Array of intervention objects with scenario name, total cost, and total cases averted
+ */
 const buildInterventions = (
 	casesAvertedData: Partial<Record<Scenario, CasesAverted>>,
 	regionForm: Record<string, FormValue>

--- a/src/routes/projects/[project]/strategise/utils.ts
+++ b/src/routes/projects/[project]/strategise/utils.ts
@@ -1,0 +1,53 @@
+import type { FormValue } from '$lib/components/dynamic-region-form/types';
+import { combineCostsAndCasesAverted, DEFAULT_POPULATION, getTotalCostsPerScenario } from '$lib/process-results/costs';
+import {
+	collectPostInterventionCases,
+	convertPer1000ToTotal,
+	getAvertedCasesData,
+	type CasesAverted
+} from '$lib/process-results/processCases';
+import type { Region, Scenario } from '$lib/types/userState';
+import type { StrategiseRegions } from './schema';
+
+export const getCasesAvertedAndCostsForStrategise = (regions: Region[]): StrategiseRegions => {
+	return regions.map(processRegionData).filter((region) => region !== null);
+};
+
+const processRegionData = (region: Region) => {
+	const casesAverted = extractCasesAvertedData(region);
+	if (!casesAverted || Object.keys(casesAverted).length === 0) {
+		return null;
+	}
+
+	const interventions = buildInterventions(casesAverted, region.formValues ?? {});
+
+	return {
+		region: region.name,
+		interventions
+	};
+};
+
+const extractCasesAvertedData = (region: Region) => {
+	const postInterventionCases = collectPostInterventionCases(region.cases);
+	return getAvertedCasesData(postInterventionCases);
+};
+
+const buildInterventions = (
+	casesAvertedData: Partial<Record<Scenario, CasesAverted>>,
+	regionForm: Record<string, FormValue>
+): StrategiseRegions[number]['interventions'] => {
+	const scenarios = Object.keys(casesAvertedData) as Scenario[];
+	const costsAndCasesAverted = combineCostsAndCasesAverted(
+		getTotalCostsPerScenario(scenarios, regionForm),
+		casesAvertedData
+	);
+
+	return Object.entries(costsAndCasesAverted).map(([scenario, { casesAverted, totalCost }]) => ({
+		intervention: scenario,
+		cost: totalCost,
+		casesAverted: convertPer1000ToTotal(
+			casesAverted.totalAvertedCasesPer1000,
+			Number(regionForm.population) || DEFAULT_POPULATION
+		)
+	}));
+};


### PR DESCRIPTION
The PR is responsible for setting up the strategy and fetching results from the corresponding R work.  This can be compared to existing [mint](https://mint-dev.dide.ic.ac.uk/strategise).  Currently we just print JSON results from R, future PRs will handle the display of table + charts.

Design decision: Before the strategise link only appeared when the user had run interventions on multiple regions. This was confusing initially because you dont know when you can strategise or not. Thus now strategise link always shows and if users visit page when they technically can not strategise they get a warning message. This is done for clarity as it gives users feedback for when they can strategise across regions. 

Note: `ui/alert` is generated from shadcn and dosent need review

The following is done in this PR:

- add strategise link when on region that will route to that page
- add strategise page with budget input and strategize button that submits and fetches results from R
- small refactors to help with strategise

Testing:
Create project with multiple scenarios and run on atleast 2 regions. Then click on strategize, select budget and run. The results are currently just printing out.



<img width="1415" height="145" alt="image" src="https://github.com/user-attachments/assets/dda90520-bfef-4588-ab59-1a629a8adbd3" />
<img width="1415" height="771" alt="image" src="https://github.com/user-attachments/assets/e6bea9fe-5492-4913-8ca4-17d63a2a2031" />
<img width="1415" height="771" alt="image" src="https://github.com/user-attachments/assets/8fdc74f1-ecbb-49da-a5b8-a44a461b8aa7" />
