### PR TITLE
Compare Cases table

### DIFF
--- a/client/e2e/utils.ts
+++ b/client/e2e/utils.ts
@@ -47,3 +47,11 @@ export const changeSlider = async (page: Page, inputId: string, targetPercent: n
 	await page.mouse.move(endX, startY, { steps: 10 });
 	await page.mouse.up();
 };
+
+export const runRegionWithItn = async (page: Page) => {
+	await changeSlider(page, 'current_malaria_prevalence', 0.2);
+	await page.getByRole('button', { name: 'Run baseline' }).click();
+	await page.waitForTimeout(500); // wait for chart to fully render
+	await changeSlider(page, 'itn_future', 0.8);
+	await page.getByRole('checkbox', { name: 'Pyrethroid-only ITNs' }).click();
+};

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -1,7 +1,7 @@
 import { convertToLocaleString } from '$lib/number';
 import { type CasesAverted, type ScenarioTotals } from '$lib/process-results/processCases';
+import type { CompareTotals } from '$lib/types/compare';
 import type { Scenario } from '$lib/types/userState';
-import type { CompareTotals } from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import { type Options, type PointOptionsObject, type SeriesColumnOptions, type SeriesLineOptions } from 'highcharts';
 import { getColumnFill, ScenarioToLabel, type ScenarioLabel } from './baseChart';
 

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -10,6 +10,10 @@ import type { CasesData, Scenario } from '$lib/types/userState';
 import { type Options, type PointOptionsObject, type SeriesColumnOptions, type SeriesLineOptions } from 'highcharts';
 import { getColumnFill, ScenarioToLabel, type ScenarioLabel } from './baseChart';
 import { convertToLocaleString } from '$lib/number';
+import type {
+	CompareFormValues,
+	CompareResults
+} from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 
 const getCasesSeriesData = (
 	casesAverted: Partial<Record<Scenario, CasesAverted>>
@@ -200,21 +204,18 @@ export const getClosestPoint = (cost: number, allSeries: Highcharts.Series[]): H
 		}, null);
 
 export const getCasesCompareConfig = (
-	presentCases: CasesData[],
-	fullLongTermCases: CasesData[],
-	baselineLongTermCases: CasesData[],
-	presentFormValues: Record<string, FormValue>,
-	longTermFormValues: Record<string, FormValue>,
+	{ present, baselineLongTerm, fullLongTerm }: CompareResults,
+	{ presentFormValues, longTermFormValues }: CompareFormValues,
 	setSelectedIntervention: (intervention: ScenarioLabel) => void
 ): Options => {
-	const presentSeries = createCasesCompareSeries(presentCases, presentFormValues, 'Present');
+	const presentSeries = createCasesCompareSeries(present.cases, presentFormValues, 'Present');
 	const baselineLongTermSeries = createCasesCompareSeries(
-		baselineLongTermCases,
+		baselineLongTerm.cases,
 		presentFormValues,
 		'Long term (baseline only)'
 	);
 	const fullLongTermSeries = createCasesCompareSeries(
-		fullLongTermCases,
+		fullLongTerm.cases,
 		longTermFormValues,
 		'Long term (baseline + control strategy)'
 	);

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -1,19 +1,9 @@
-import type { FormValue } from '$lib/components/dynamic-region-form/types';
-import { getTotalCostsPerScenario } from '$lib/process-results/costs';
-import {
-	collectPostInterventionCases,
-	convertPer1000ToTotal,
-	getTotalCasesPer1000,
-	type CasesAverted
-} from '$lib/process-results/processCases';
-import type { CasesData, Scenario } from '$lib/types/userState';
+import { convertToLocaleString } from '$lib/number';
+import { type CasesAverted, type ScenarioTotals } from '$lib/process-results/processCases';
+import type { Scenario } from '$lib/types/userState';
+import type { CompareTotals } from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import { type Options, type PointOptionsObject, type SeriesColumnOptions, type SeriesLineOptions } from 'highcharts';
 import { getColumnFill, ScenarioToLabel, type ScenarioLabel } from './baseChart';
-import { convertToLocaleString } from '$lib/number';
-import type {
-	CompareFormValues,
-	CompareResults
-} from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 
 const getCasesSeriesData = (
 	casesAverted: Partial<Record<Scenario, CasesAverted>>
@@ -112,35 +102,24 @@ export const filterInefficientStrategies = (dataPoints: CasesCompareDataPoint[])
 	}, []);
 };
 export const createCasesCompareDataPoints = (
-	cases: CasesData[],
-	formValues: Record<string, FormValue>
+	totalCasesAndCosts: Partial<Record<Scenario, ScenarioTotals>>
 ): CasesCompareDataPoint[] => {
-	const postInterventionCases = collectPostInterventionCases(cases);
-	const scenarios = Object.entries(postInterventionCases)
-		.filter(([_, scenarioCases]) => scenarioCases.length > 0)
-		.map(([scenario]) => scenario as Scenario);
-	const scenarioCosts = getTotalCostsPerScenario(scenarios, formValues);
+	const totalCasesAndCostsArray = Object.entries(totalCasesAndCosts).map(([scenario, { totalCases, totalCost }]) => ({
+		scenario: scenario as Scenario,
+		totalCases,
+		totalCost: totalCost
+	}));
 
-	const casesByTotalCost = scenarios.map((scenario) => {
-		const totalCasesPer1000 = getTotalCasesPer1000(postInterventionCases[scenario]);
-		return {
-			scenario,
-			totalCases: convertPer1000ToTotal(totalCasesPer1000, Number(formValues['population'])),
-			totalCost: scenarioCosts[scenario]!
-		};
-	});
-
-	return filterInefficientStrategies(casesByTotalCost);
+	return filterInefficientStrategies(totalCasesAndCostsArray);
 };
 
 export const createCasesCompareSeries = (
-	cases: CasesData[],
-	formValues: Record<string, FormValue>,
+	totalCasesAndCosts: Partial<Record<Scenario, ScenarioTotals>>,
 	name: 'Present' | 'Long term (baseline + control strategy)' | 'Long term (baseline only)'
 ): SeriesLineOptions => ({
 	name,
 	type: 'line',
-	data: createCasesCompareDataPoints(cases, formValues).map(({ totalCases, totalCost, scenario }) => ({
+	data: createCasesCompareDataPoints(totalCasesAndCosts).map(({ totalCases, totalCost, scenario }) => ({
 		x: totalCost,
 		y: totalCases,
 		custom: {
@@ -204,23 +183,15 @@ export const getClosestPoint = (cost: number, allSeries: Highcharts.Series[]): H
 		}, null);
 
 export const getCasesCompareConfig = (
-	{ present, baselineLongTerm, fullLongTerm }: CompareResults,
-	{ presentFormValues, longTermFormValues }: CompareFormValues,
+	{ presentTotals, baselineLongTermTotals, fullLongTermTotals }: CompareTotals,
 	setSelectedIntervention: (intervention: ScenarioLabel) => void
 ): Options => {
-	const presentSeries = createCasesCompareSeries(present.cases, presentFormValues, 'Present');
-	const baselineLongTermSeries = createCasesCompareSeries(
-		baselineLongTerm.cases,
-		presentFormValues,
-		'Long term (baseline only)'
-	);
-	const fullLongTermSeries = createCasesCompareSeries(
-		fullLongTerm.cases,
-		longTermFormValues,
-		'Long term (baseline + control strategy)'
-	);
+	const presentSeries = createCasesCompareSeries(presentTotals, 'Present');
+	const baselineLongTermSeries = createCasesCompareSeries(baselineLongTermTotals, 'Long term (baseline only)');
+	const fullLongTermSeries = createCasesCompareSeries(fullLongTermTotals, 'Long term (baseline + control strategy)');
 	const presentData = presentSeries.data as PointOptionsObject[];
 	const fullLongTermData = fullLongTermSeries.data as PointOptionsObject[];
+
 	return {
 		chart: {
 			type: 'line',

--- a/client/src/lib/charts/prevalenceConfig.ts
+++ b/client/src/lib/charts/prevalenceConfig.ts
@@ -1,5 +1,5 @@
+import type { CompareResults } from '$lib/types/compare';
 import { SCENARIOS, type PrevalenceData, type Scenario } from '$lib/types/userState';
-import type { CompareResults } from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import { ScenarioToColor, ScenarioToLabel, type ScenarioLabel } from './baseChart';
 
 const createPrevalenceSeries = (data: PrevalenceData[]): Highcharts.SeriesSplineOptions[] => {

--- a/client/src/lib/charts/prevalenceConfig.ts
+++ b/client/src/lib/charts/prevalenceConfig.ts
@@ -1,4 +1,5 @@
 import { SCENARIOS, type PrevalenceData, type Scenario } from '$lib/types/userState';
+import type { CompareResults } from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import { ScenarioToColor, ScenarioToLabel, type ScenarioLabel } from './baseChart';
 
 const createPrevalenceSeries = (data: PrevalenceData[]): Highcharts.SeriesSplineOptions[] => {
@@ -113,15 +114,13 @@ export const createComparisonSeries = (
 		}));
 
 export const getPrevalenceConfigCompare = (
-	presentPrevalence: PrevalenceData[],
-	baselineLongTermPrevalence: PrevalenceData[],
-	fullLongTermPrevalence: PrevalenceData[],
+	{ present, baselineLongTerm, fullLongTerm }: CompareResults,
 	selectedIntervention: ScenarioLabel
 ): Highcharts.Options => {
 	const series: Highcharts.SeriesSplineOptions[] = [
-		{ data: presentPrevalence, name: 'Present' },
-		{ data: baselineLongTermPrevalence, name: 'Long term (baseline only)' },
-		{ data: fullLongTermPrevalence, name: 'Long term (baseline + control strategy)' }
+		{ data: present.prevalence, name: 'Present' },
+		{ data: baselineLongTerm.prevalence, name: 'Long term (baseline only)' },
+		{ data: fullLongTerm.prevalence, name: 'Long term (baseline + control strategy)' }
 	].flatMap(({ data, name }) => createComparisonSeries(data, selectedIntervention, name));
 
 	return {

--- a/client/src/lib/components/data-table/DataTable.svelte
+++ b/client/src/lib/components/data-table/DataTable.svelte
@@ -40,7 +40,7 @@
 			{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
 				<Table.Row>
 					{#each headerGroup.headers as header (header.id)}
-						<Table.Head colspan={header.colSpan} class="whitespace-normal">
+						<Table.Head colspan={header.colSpan} class="p-2.5 whitespace-normal">
 							{#if !header.isPlaceholder}
 								<FlexRender content={header.column.columnDef.header} context={header.getContext()} />
 							{/if}
@@ -53,7 +53,7 @@
 			{#each table.getRowModel().rows as row (row.id)}
 				<Table.Row data-state={row.getIsSelected() && 'selected'}>
 					{#each row.getVisibleCells() as cell (cell.id)}
-						<Table.Cell class="whitespace-normal">
+						<Table.Cell class="p-2.5 whitespace-normal">
 							<FlexRender content={cell.column.columnDef.cell} context={cell.getContext()} />
 						</Table.Cell>
 					{/each}

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -70,12 +70,12 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 		columns: [
 			{
 				accessorKey: 'fullLongTermCases',
-				cell: (info) => info.getValue(),
+				cell: ({ getValue }) => getValue(),
 				header: 'Cases'
 			},
 			{
 				accessorKey: 'fullLongTermCost',
-				cell: (info) => info.getValue(),
+				cell: ({ getValue }) => getValue(),
 				header: 'Cost'
 			}
 		]

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -1,18 +1,9 @@
 import { ScenarioToLabel } from '$lib/charts/baseChart';
 import DataTableSortHeader from '$lib/components/data-table/DataTableSortHeader.svelte';
-import type { FormValue } from '$lib/components/dynamic-region-form/types';
 import { renderComponent } from '$lib/components/ui/data-table';
-import { getTotalCostsPerScenario } from '$lib/process-results/costs';
-import {
-	collectPostInterventionCases,
-	convertPer1000ToTotal,
-	getTotalCasesPer1000
-} from '$lib/process-results/processCases';
-import type { CasesData, Scenario } from '$lib/types/userState';
-import type {
-	CompareFormValues,
-	CompareResults
-} from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
+import { type ScenarioTotals } from '$lib/process-results/processCases';
+import type { Scenario } from '$lib/types/userState';
+import type { CompareTotals } from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import type { CellContext, ColumnDef, HeaderContext } from '@tanstack/table-core';
 
 export interface ComparisonTimeFramesData {
@@ -133,56 +124,24 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	}
 ];
 
-interface ScenarioTotals {
-	totalCost: number;
-	totalCases: number;
-}
-
-const createCasesSummary = (
-	cases: CasesData[],
-	formValues: Record<string, FormValue>
-): Partial<Record<Scenario, ScenarioTotals>> => {
-	const postInterventionCases = collectPostInterventionCases(cases);
-	const scenarios = Object.entries(postInterventionCases)
-		.filter(([_, scenarioCases]) => scenarioCases.length > 0)
-		.map(([scenario]) => scenario as Scenario);
-	const scenarioCosts = getTotalCostsPerScenario(scenarios, formValues);
-
-	const totalsByScenario = {} as Partial<Record<Scenario, ScenarioTotals>>;
-	const population = Number(formValues['population']);
-	for (const scenario of scenarios) {
-		const totalCasesPer1000 = getTotalCasesPer1000(postInterventionCases[scenario]);
-
-		totalsByScenario[scenario as Scenario] = {
-			totalCost: scenarioCosts[scenario] ?? 0,
-			totalCases: convertPer1000ToTotal(totalCasesPer1000, population)
-		};
-	}
-
-	return totalsByScenario;
-};
-
 const getScenarioKeys = (...summaryByTimeFrames: Partial<Record<Scenario, ScenarioTotals>>[]): Scenario[] => [
 	...new Set(summaryByTimeFrames.flatMap((summary) => Object.keys(summary) as Scenario[]))
 ];
 
-export const buildCompareCasesTableData = (
-	{ present, baselineLongTerm, fullLongTerm }: CompareResults,
-	{ presentFormValues, longTermFormValues }: CompareFormValues
-): ComparisonTimeFramesData[] => {
-	const presentData = createCasesSummary(present.cases, presentFormValues);
-	const baselineLongTermData = createCasesSummary(baselineLongTerm.cases, presentFormValues);
-	const fullLongTermData = createCasesSummary(fullLongTerm.cases, longTermFormValues);
-
-	const scenarios = getScenarioKeys(presentData, baselineLongTermData, fullLongTermData);
+export const buildCompareCasesTableData = ({
+	presentTotals,
+	baselineLongTermTotals,
+	fullLongTermTotals
+}: CompareTotals): ComparisonTimeFramesData[] => {
+	const scenarios = getScenarioKeys(presentTotals, baselineLongTermTotals, fullLongTermTotals);
 
 	return scenarios.map((scenario) => ({
 		intervention: ScenarioToLabel[scenario as Scenario],
-		presentCost: presentData[scenario as Scenario]?.totalCost,
-		presentCases: presentData[scenario as Scenario]?.totalCases,
-		longTermBaselineCost: baselineLongTermData[scenario as Scenario]?.totalCost,
-		longTermBaselineCases: baselineLongTermData[scenario as Scenario]?.totalCases,
-		fullLongTermCost: fullLongTermData[scenario as Scenario]?.totalCost,
-		fullLongTermCases: fullLongTermData[scenario as Scenario]?.totalCases
+		presentCost: presentTotals[scenario as Scenario]?.totalCost,
+		presentCases: presentTotals[scenario as Scenario]?.totalCases,
+		longTermBaselineCost: baselineLongTermTotals[scenario as Scenario]?.totalCost,
+		longTermBaselineCases: baselineLongTermTotals[scenario as Scenario]?.totalCases,
+		fullLongTermCost: fullLongTermTotals[scenario as Scenario]?.totalCost,
+		fullLongTermCases: fullLongTermTotals[scenario as Scenario]?.totalCases
 	}));
 };

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -16,7 +16,7 @@ export interface ComparisonTimeFramesData {
 	fullLongTermCases?: number;
 }
 
-const getCasesHeader = () => ({
+export const getCasesHeader = () => ({
 	header: ({ column }: HeaderContext<ComparisonTimeFramesData, string>) => {
 		return renderComponent(DataTableSortHeader, {
 			onclick: column.getToggleSortingHandler(),
@@ -39,7 +39,7 @@ export const getCasesCell = () => ({
 	}
 });
 
-const getCostsHeader = () => ({
+export const getCostsHeader = () => ({
 	header: ({ column }: HeaderContext<ComparisonTimeFramesData, string>) => {
 		return renderComponent(DataTableSortHeader, {
 			onclick: column.getToggleSortingHandler(),
@@ -124,9 +124,8 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	}
 ];
 
-const getScenarioKeys = (...summaryByTimeFrames: Partial<Record<Scenario, ScenarioTotals>>[]): Scenario[] => [
-	...new Set(summaryByTimeFrames.flatMap((summary) => Object.keys(summary) as Scenario[]))
-];
+export const getScenarioKeys = (...totalsByTImeFrames: Partial<Record<Scenario, ScenarioTotals>>[]): Scenario[] =>
+	Array.from(new Set(totalsByTImeFrames.flatMap((summary) => Object.keys(summary) as Scenario[])));
 
 export const buildCompareCasesTableData = ({
 	presentTotals,

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -17,7 +17,7 @@ export interface ComparisonTimeFramesData {
 }
 
 export const getCasesHeader = () => ({
-	header: ({ column }: HeaderContext<ComparisonTimeFramesData, string>) => {
+	header: ({ column }: HeaderContext<ComparisonTimeFramesData, number | undefined>) => {
 		return renderComponent(DataTableSortHeader, {
 			onclick: column.getToggleSortingHandler(),
 			label: 'Cases'
@@ -40,7 +40,7 @@ export const getCasesCell = () => ({
 });
 
 export const getCostsHeader = () => ({
-	header: ({ column }: HeaderContext<ComparisonTimeFramesData, string>) => {
+	header: ({ column }: HeaderContext<ComparisonTimeFramesData, number | undefined>) => {
 		return renderComponent(DataTableSortHeader, {
 			onclick: column.getToggleSortingHandler(),
 			label: 'Cost'

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -2,8 +2,8 @@ import { ScenarioToLabel } from '$lib/charts/baseChart';
 import DataTableSortHeader from '$lib/components/data-table/DataTableSortHeader.svelte';
 import { renderComponent } from '$lib/components/ui/data-table';
 import { type ScenarioTotals } from '$lib/process-results/processCases';
+import type { CompareTotals } from '$lib/types/compare';
 import type { Scenario } from '$lib/types/userState';
-import type { CompareTotals } from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import type { CellContext, ColumnDef, HeaderContext } from '@tanstack/table-core';
 
 export interface ComparisonTimeFramesData {

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -12,27 +12,73 @@ import type { ColumnDef } from '@tanstack/table-core';
 
 export interface ComparisonTimeFramesData {
 	intervention: string;
-	present: string;
-	longTermBaseline: string;
-	fullLongTerm: string;
+	presentCost: string;
+	presentCases: string;
+	longTermBaselineCost: string;
+	longTermBaselineCases: string;
+	fullLongTermCost: string;
+	fullLongTermCases: string;
 }
 
 export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	{
 		accessorKey: 'intervention',
-		header: 'Intervention'
+		header: 'Intervention',
+		columns: [
+			{
+				accessorKey: 'intervention',
+				cell: ({ getValue }) => getValue(),
+				header: ''
+			}
+		]
 	},
 	{
 		accessorKey: 'present',
-		header: 'Present'
+		header: 'Present',
+		columns: [
+			{
+				accessorKey: 'presentCases',
+				cell: ({ getValue }) => getValue(),
+				header: 'Cases'
+			},
+			{
+				accessorKey: 'presentCost',
+				cell: ({ getValue }) => getValue(),
+				header: 'Cost'
+			}
+		]
 	},
 	{
 		accessorKey: 'longTermBaseline',
-		header: 'Long term (baseline only)'
+		header: 'Long term (baseline only)',
+		columns: [
+			{
+				accessorKey: 'longTermBaselineCases',
+				cell: ({ getValue }) => getValue(),
+				header: 'Cases'
+			},
+			{
+				accessorKey: 'longTermBaselineCost',
+				cell: ({ getValue }) => getValue(),
+				header: 'Cost'
+			}
+		]
 	},
 	{
 		accessorKey: 'fullLongTerm',
-		header: 'Long term (baseline + control strategy)'
+		header: 'Long term (baseline + control strategy)',
+		columns: [
+			{
+				accessorKey: 'fullLongTermCases',
+				cell: (info) => info.getValue(),
+				header: 'Cases'
+			},
+			{
+				accessorKey: 'fullLongTermCost',
+				cell: (info) => info.getValue(),
+				header: 'Cost'
+			}
+		]
 	}
 ];
 
@@ -68,10 +114,8 @@ const getScenarioKeys = (...summaryByTimeFrames: Partial<Record<Scenario, Scenar
 	...new Set(summaryByTimeFrames.flatMap((summary) => Object.keys(summary) as Scenario[]))
 ];
 
-const formatScenarioTotals = (totals?: ScenarioTotals): string =>
-	totals
-		? `${convertToLocaleString(totals.totalCases, 1)} cases, $${convertToLocaleString(totals.totalCost, 1)}`
-		: 'N/A';
+const formatCell = (value?: number, prefix?: string): string =>
+	value !== undefined ? `${prefix || ''}${convertToLocaleString(value, 0)}` : 'N/A';
 
 export const buildCompareCasesTableData = (
 	presentCases: CasesData[],
@@ -88,8 +132,11 @@ export const buildCompareCasesTableData = (
 
 	return scenarios.map((scenario) => ({
 		intervention: ScenarioToLabel[scenario as Scenario],
-		present: formatScenarioTotals(presentData[scenario as Scenario]),
-		longTermBaseline: formatScenarioTotals(baselineLongTermData[scenario as Scenario]),
-		fullLongTerm: formatScenarioTotals(fullLongTermData[scenario as Scenario])
+		presentCost: formatCell(presentData[scenario as Scenario]?.totalCost, '$'),
+		presentCases: formatCell(presentData[scenario as Scenario]?.totalCases),
+		longTermBaselineCost: formatCell(baselineLongTermData[scenario as Scenario]?.totalCost, '$'),
+		longTermBaselineCases: formatCell(baselineLongTermData[scenario as Scenario]?.totalCases),
+		fullLongTermCost: formatCell(fullLongTermData[scenario as Scenario]?.totalCost, '$'),
+		fullLongTermCases: formatCell(fullLongTermData[scenario as Scenario]?.totalCases)
 	}));
 };

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -1,0 +1,91 @@
+import { ScenarioToLabel } from '$lib/charts/baseChart';
+import type { FormValue } from '$lib/components/dynamic-region-form/types';
+import { convertToLocaleString } from '$lib/number';
+import { getTotalCostsPerScenario } from '$lib/process-results/costs';
+import {
+	collectPostInterventionCases,
+	convertPer1000ToTotal,
+	getTotalCasesPer1000
+} from '$lib/process-results/processCases';
+import type { CasesData, Scenario } from '$lib/types/userState';
+import type { ColumnDef } from '@tanstack/table-core';
+
+export interface ComparisonTimeFramesData {
+	intervention: string;
+	present: string;
+	longTermBaseline: string;
+	fullLongTerm: string;
+}
+
+export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
+	{
+		accessorKey: 'intervention',
+		header: 'Intervention'
+	},
+	{
+		accessorKey: 'present',
+		header: 'Present'
+	},
+	{
+		accessorKey: 'longTermBaseline',
+		header: 'Long term (baseline only)'
+	},
+	{
+		accessorKey: 'fullLongTerm',
+		header: 'Long term (baseline + control strategy)'
+	}
+];
+
+const createComparisonTimeFramesData = (cases: CasesData[], formValues: Record<string, FormValue>) => {
+	const postInterventionCases = collectPostInterventionCases(cases);
+	const scenarios = Object.entries(postInterventionCases)
+		.filter(([_, scenarioCases]) => scenarioCases.length > 0)
+		.map(([scenario]) => scenario as Scenario);
+	const scenarioCosts = getTotalCostsPerScenario(scenarios, formValues);
+
+	const casesByTotalCost = scenarios.map((scenario) => {
+		const totalCasesPer1000 = getTotalCasesPer1000(postInterventionCases[scenario]);
+		return {
+			scenario,
+			totalCases: convertPer1000ToTotal(totalCasesPer1000, Number(formValues['population'])),
+			totalCost: scenarioCosts[scenario]!
+		};
+	});
+
+	return casesByTotalCost;
+};
+export const buildCompareCasesTableData = (
+	presentCases: CasesData[],
+	fullLongTermCases: CasesData[],
+	baselineLongTermCases: CasesData[],
+	presentFormValues: Record<string, FormValue>,
+	longTermFormValues: Record<string, FormValue>
+): ComparisonTimeFramesData[] => {
+	const presentData = createComparisonTimeFramesData(presentCases, presentFormValues);
+	const baselineLongTermData = createComparisonTimeFramesData(baselineLongTermCases, presentFormValues);
+	const fullLongTermData = createComparisonTimeFramesData(fullLongTermCases, longTermFormValues);
+
+	const scenarios = [...new Set([...presentData, ...baselineLongTermData, ...fullLongTermData].map((d) => d.scenario))];
+	const tableData: ComparisonTimeFramesData[] = [];
+
+	for (const scenario of scenarios) {
+		const presentScenario = presentData.find((d) => d.scenario === scenario);
+		const fullLongTermScenario = fullLongTermData.find((d) => d.scenario === scenario);
+		const baselineLongTermScenario = baselineLongTermData.find((d) => d.scenario === scenario);
+
+		tableData.push({
+			intervention: ScenarioToLabel[scenario],
+			present: presentScenario
+				? `${convertToLocaleString(presentScenario.totalCases, 1)} cases - $${convertToLocaleString(presentScenario.totalCost, 0)}`
+				: 'N/A',
+			longTermBaseline: baselineLongTermScenario
+				? `${convertToLocaleString(baselineLongTermScenario.totalCases, 1)} cases - $${convertToLocaleString(baselineLongTermScenario.totalCost, 0)}`
+				: 'N/A',
+			fullLongTerm: fullLongTermScenario
+				? `${convertToLocaleString(fullLongTermScenario.totalCases, 1)} cases - $${convertToLocaleString(fullLongTermScenario.totalCost, 0)}`
+				: 'N/A'
+		});
+	}
+
+	return tableData;
+};

--- a/client/src/lib/types/compare.ts
+++ b/client/src/lib/types/compare.ts
@@ -1,3 +1,6 @@
+import type { ScenarioTotals } from '$lib/process-results/processCases';
+import type { EmulatorResults, Scenario } from './userState';
+
 export interface CompareParameter {
 	parameterName: string;
 	label: string;
@@ -16,4 +19,16 @@ export interface InterventionCompareParameter extends CompareParameter {
 export interface CompareParameters {
 	baselineParameters: CompareParameter[];
 	interventionParameters: InterventionCompareParameter[];
+}
+
+export type CompareSeriesName = 'Present' | 'Long term (baseline + control strategy)' | 'Long term (baseline only)';
+export interface CompareResults {
+	present: EmulatorResults;
+	fullLongTerm: EmulatorResults;
+	baselineLongTerm: EmulatorResults;
+}
+export interface CompareTotals {
+	presentTotals: Partial<Record<Scenario, ScenarioTotals>>;
+	baselineLongTermTotals: Partial<Record<Scenario, ScenarioTotals>>;
+	fullLongTermTotals: Partial<Record<Scenario, ScenarioTotals>>;
 }

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
@@ -12,7 +12,7 @@
 	import { toast } from 'svelte-sonner';
 	import { runCompareEmulator } from '../utils';
 	import InterventionFields from './InterventionFields.svelte';
-	import Plots from './Plots.svelte';
+	import CompareResults from './CompareResults.svelte';
 
 	interface Props {
 		presentResults: EmulatorResults;
@@ -118,13 +118,17 @@
 			<Loader text="Loading..." />
 		</div>
 	{:else}
-		<Plots
+		<CompareResults
 			{chartTheme}
-			{presentResults}
-			{fullLongTermResults}
-			{baselineLongTermResults}
-			{presentFormValues}
-			{longTermFormValues}
+			results={{
+				present: presentResults,
+				fullLongTerm: fullLongTermResults,
+				baselineLongTerm: baselineLongTermResults
+			}}
+			formValues={{
+				presentFormValues,
+				longTermFormValues
+			}}
 		/>
 	{/if}
 </div>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -2,22 +2,11 @@
 	import { createHighchart, type ScenarioLabel } from '$lib/charts/baseChart';
 	import { getCasesCompareConfig } from '$lib/charts/casesConfig';
 	import { getPrevalenceConfigCompare } from '$lib/charts/prevalenceConfig';
-	import type { FormValue } from '$lib/components/dynamic-region-form/types';
-	import type { EmulatorResults } from '$lib/types/userState';
-	import { buildCompareCasesTableData, compareCasesTableColumns } from '$lib/tables/compareCasesTable';
 	import DataTable from '$lib/components/data-table/DataTable.svelte';
+	import type { FormValue } from '$lib/components/dynamic-region-form/types';
 	import { getTotalCasesAndCostsPerScenario } from '$lib/process-results/processCases';
-
-	export interface CompareResults {
-		present: EmulatorResults;
-		fullLongTerm: EmulatorResults;
-		baselineLongTerm: EmulatorResults;
-	}
-	export interface CompareTotals {
-		presentTotals: ReturnType<typeof getTotalCasesAndCostsPerScenario>;
-		baselineLongTermTotals: ReturnType<typeof getTotalCasesAndCostsPerScenario>;
-		fullLongTermTotals: ReturnType<typeof getTotalCasesAndCostsPerScenario>;
-	}
+	import { buildCompareCasesTableData, compareCasesTableColumns } from '$lib/tables/compareCasesTable';
+	import type { CompareResults } from '$lib/types/compare';
 
 	interface Props {
 		chartTheme: string;

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -7,52 +7,30 @@
 	import { buildCompareCasesTableData, compareCasesTableColumns } from '$lib/tables/compareCasesTable';
 	import DataTable from '$lib/components/data-table/DataTable.svelte';
 
-	interface Props {
-		chartTheme: string;
-		presentResults: EmulatorResults;
+	export interface CompareResults {
+		present: EmulatorResults;
+		fullLongTerm: EmulatorResults;
+		baselineLongTerm: EmulatorResults;
+	}
+	export interface CompareFormValues {
 		presentFormValues: Record<string, FormValue>;
 		longTermFormValues: Record<string, FormValue>;
-		fullLongTermResults: EmulatorResults;
-		baselineLongTermResults: EmulatorResults;
 	}
-	let {
-		chartTheme,
-		presentResults,
-		fullLongTermResults,
-		presentFormValues,
-		longTermFormValues,
-		baselineLongTermResults
-	}: Props = $props();
+
+	interface Props {
+		chartTheme: string;
+		results: CompareResults;
+		formValues: CompareFormValues;
+	}
+	let { chartTheme, results, formValues }: Props = $props();
 	let selectedIntervention = $state<ScenarioLabel>('No Intervention');
 
-	let prevalenceConfig = $derived(
-		getPrevalenceConfigCompare(
-			presentResults.prevalence,
-			baselineLongTermResults.prevalence,
-			fullLongTermResults.prevalence,
-			selectedIntervention
-		)
-	);
+	let prevalenceConfig = $derived(getPrevalenceConfigCompare(results, selectedIntervention));
 	let casesConfig = $derived(
-		getCasesCompareConfig(
-			presentResults.cases,
-			fullLongTermResults.cases,
-			baselineLongTermResults.cases,
-			presentFormValues,
-			longTermFormValues,
-			(intervention) => (selectedIntervention = intervention)
-		)
+		getCasesCompareConfig(results, formValues, (intervention) => (selectedIntervention = intervention))
 	);
 
-	let tableData = $derived(
-		buildCompareCasesTableData(
-			presentResults.cases,
-			fullLongTermResults.cases,
-			baselineLongTermResults.cases,
-			presentFormValues,
-			longTermFormValues
-		)
-	);
+	let tableData = $derived(buildCompareCasesTableData(results, formValues));
 </script>
 
 <div class="flex flex-3/4 flex-col gap-4">

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Plots.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Plots.svelte
@@ -4,7 +4,6 @@
 	import { getPrevalenceConfigCompare } from '$lib/charts/prevalenceConfig';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
 	import type { EmulatorResults } from '$lib/types/userState';
-	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import { buildCompareCasesTableData, compareCasesTableColumns } from '$lib/tables/compareCasesTable';
 	import DataTable from '$lib/components/data-table/DataTable.svelte';
 
@@ -56,24 +55,14 @@
 	);
 </script>
 
-<div class="flex flex-3/4 flex-col">
-	<Tabs.Root value="plot">
-		<div class="flex gap-2">
-			<Tabs.List class="w-full">
-				<Tabs.Trigger value="plot">Plots</Tabs.Trigger>
-				<Tabs.Trigger value="table">Table</Tabs.Trigger>
-			</Tabs.List>
-		</div>
-		<Tabs.Content value="plot" class="flex flex-col gap-4">
-			<section aria-label="cases compare graph" class="rounded-lg border p-2">
-				<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
-			</section>
-			<section aria-label="prevalence compare graph" class="rounded-lg border p-2">
-				<div {@attach createHighchart(prevalenceConfig)} class={chartTheme}></div>
-			</section>
-		</Tabs.Content>
-		<Tabs.Content value="table">
-			<DataTable data={tableData} columns={compareCasesTableColumns} />
-		</Tabs.Content>
-	</Tabs.Root>
+<div class="flex flex-3/4 flex-col gap-4">
+	<section aria-label="cases compare graph" class="rounded-lg border p-2">
+		<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
+	</section>
+	<section aria-label="prevalence compare graph" class="rounded-lg border p-2">
+		<div {@attach createHighchart(prevalenceConfig)} class={chartTheme}></div>
+	</section>
+	<section aria-label="cases compare table">
+		<DataTable data={tableData} columns={compareCasesTableColumns} />
+	</section>
 </div>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Plots.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Plots.svelte
@@ -4,6 +4,9 @@
 	import { getPrevalenceConfigCompare } from '$lib/charts/prevalenceConfig';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
 	import type { EmulatorResults } from '$lib/types/userState';
+	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import { buildCompareCasesTableData, compareCasesTableColumns } from '$lib/tables/compareCasesTable';
+	import DataTable from '$lib/components/data-table/DataTable.svelte';
 
 	interface Props {
 		chartTheme: string;
@@ -41,13 +44,36 @@
 			(intervention) => (selectedIntervention = intervention)
 		)
 	);
+
+	let tableData = $derived(
+		buildCompareCasesTableData(
+			presentResults.cases,
+			fullLongTermResults.cases,
+			baselineLongTermResults.cases,
+			presentFormValues,
+			longTermFormValues
+		)
+	);
 </script>
 
-<div class="flex flex-3/4 flex-col gap-4">
-	<section aria-label="cases compare graph" class="rounded-lg border p-2">
-		<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
-	</section>
-	<section aria-label="prevalence compare graph" class="rounded-lg border p-2">
-		<div {@attach createHighchart(prevalenceConfig)} class={chartTheme}></div>
-	</section>
+<div class="flex flex-3/4 flex-col">
+	<Tabs.Root value="plot">
+		<div class="flex gap-2">
+			<Tabs.List class="w-full">
+				<Tabs.Trigger value="plot">Plots</Tabs.Trigger>
+				<Tabs.Trigger value="table">Table</Tabs.Trigger>
+			</Tabs.List>
+		</div>
+		<Tabs.Content value="plot" class="flex flex-col gap-4">
+			<section aria-label="cases compare graph" class="rounded-lg border p-2">
+				<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
+			</section>
+			<section aria-label="prevalence compare graph" class="rounded-lg border p-2">
+				<div {@attach createHighchart(prevalenceConfig)} class={chartTheme}></div>
+			</section>
+		</Tabs.Content>
+		<Tabs.Content value="table">
+			<DataTable data={tableData} columns={compareCasesTableColumns} />
+		</Tabs.Content>
+	</Tabs.Root>
 </div>

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -1,19 +1,18 @@
-import { describe, it, expect } from 'vitest';
 import {
 	createBreakToMinimizeEmptySpace,
 	createCasesCompareDataPoints,
 	createCasesCompareSeries,
-	getCasesConfig,
-	getCasesCompareConfig,
 	createCompareTooltipHtml,
 	filterInefficientStrategies,
+	getCasesCompareConfig,
+	getCasesConfig,
 	getClosestPoint
 } from '$lib/charts/casesConfig';
 import * as processCases from '$lib/process-results/processCases';
-import type { CasesData, Scenario } from '$lib/types/userState';
-import type { FormValue } from '$lib/components/dynamic-region-form/types';
-import * as costs from '$lib/process-results/costs';
+import type { Scenario } from '$lib/types/userState';
+import type { CompareTotals } from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import type { PointOptionsObject } from 'highcharts';
+import { describe, expect, it } from 'vitest';
 describe('getCasesConfig', () => {
 	const mockCasesAverted: Partial<Record<Scenario, processCases.CasesAverted>> = {
 		irs_only: {
@@ -196,33 +195,26 @@ describe('getCasesConfig', () => {
 });
 
 describe('cases compare config', () => {
-	const mockCases: CasesData[] = [
-		{ scenario: 'irs_only', casesPer1000: 10, year: 2 },
-		{ scenario: 'irs_only', casesPer1000: 10, year: 3 },
-		{ scenario: 'py_only_only', casesPer1000: 20, year: 2 },
-		{ scenario: 'py_only_only', casesPer1000: 20, year: 3 },
-		{ scenario: 'py_only_with_lsm', casesPer1000: 15, year: 2 },
-		{ scenario: 'py_only_with_lsm', casesPer1000: 15, year: 3 }
-	];
-
-	const mockPresentFormValues: Record<string, FormValue> = {
-		population: 10000
+	const totals: CompareTotals['presentTotals'] = {
+		py_only_only: {
+			totalCost: 1000,
+			totalCases: 500
+		},
+		irs_only: {
+			// inefficient strategy (higher cost, more cases than py_only_only)
+			totalCost: 1100,
+			totalCases: 600
+		},
+		lsm_only: {
+			totalCost: 1200,
+			totalCases: 300
+		}
 	};
-	const mockLongTermFormValues: Record<string, FormValue> = {
-		population: 20000
+	const compareTotals = {
+		presentTotals: totals,
+		baselineLongTermTotals: totals,
+		fullLongTermTotals: totals
 	};
-
-	beforeEach(() => {
-		vi.resetAllMocks();
-		vi.spyOn(processCases, 'collectPostInterventionCases');
-		vi.spyOn(processCases, 'getTotalCasesPer1000').mockReturnValue(100);
-		vi.spyOn(processCases, 'convertPer1000ToTotal').mockReturnValue(1000);
-		vi.spyOn(costs, 'getTotalCostsPerScenario').mockReturnValue({
-			irs_only: 5000,
-			py_only_only: 2000,
-			py_only_with_lsm: 8000
-		});
-	});
 
 	describe('getClosesPoint', () => {
 		it('getClosestPoint should return null for empty series data', () => {
@@ -283,47 +275,24 @@ describe('cases compare config', () => {
 		});
 	});
 	describe('createCasesCompareDataPoints', () => {
-		it('should filter out non-improving strategies after sorting by cost', () => {
-			vi.spyOn(processCases, 'collectPostInterventionCases').mockReturnValue({
-				irs_only: [{ scenario: 'irs_only', casesPer1000: 1, year: 2 }],
-				py_only_only: [{ scenario: 'py_only_only', casesPer1000: 1, year: 2 }],
-				py_only_with_lsm: [{ scenario: 'py_only_with_lsm', casesPer1000: 1, year: 2 }]
-			} as any);
-
-			vi.spyOn(costs, 'getTotalCostsPerScenario').mockReturnValue({
-				irs_only: 3000,
-				py_only_only: 1000,
-				py_only_with_lsm: 2000
-			});
-
-			vi.spyOn(processCases, 'getTotalCasesPer1000').mockReturnValue(100);
-
-			vi.spyOn(processCases, 'convertPer1000ToTotal')
-				.mockReturnValueOnce(960) // irs_only
-				.mockReturnValueOnce(1000) // py_only_only
-				.mockReturnValueOnce(950); // py_only_with_lsm
-
-			const result = createCasesCompareDataPoints([] as any, mockPresentFormValues);
+		it('should return data points filtering out inefficient strategies', () => {
+			const result = createCasesCompareDataPoints(totals);
 
 			expect(result).toEqual([
-				{ scenario: 'py_only_only', totalCases: 1000, totalCost: 1000 },
-				{ scenario: 'py_only_with_lsm', totalCases: 950, totalCost: 2000 }
+				{ scenario: 'py_only_only', totalCases: 500, totalCost: 1000 },
+				{ scenario: 'lsm_only', totalCases: 300, totalCost: 1200 }
 			]);
 		});
 
-		it('should handle empty cases array', () => {
-			const result = createCasesCompareDataPoints([], mockPresentFormValues);
+		it('should handle empty object', () => {
+			const result = createCasesCompareDataPoints({});
 			expect(result).toEqual([]);
 		});
 	});
 
 	describe('createCasesCompareSeries', () => {
 		it('should create a series with correct name and data points', () => {
-			vi.spyOn(processCases, 'convertPer1000ToTotal')
-				.mockReturnValueOnce(960) // irs_only
-				.mockReturnValueOnce(1000) // py_only_only
-				.mockReturnValueOnce(950); // py_only_with_lsm
-			const series = createCasesCompareSeries(mockCases, mockPresentFormValues, 'Present');
+			const series = createCasesCompareSeries(totals, 'Present');
 
 			expect(series.name).toBe('Present');
 			expect(series.type).toBe('line');
@@ -331,14 +300,14 @@ describe('cases compare config', () => {
 
 			expect(series.data).toHaveLength(2);
 			expect(series.data![0]).toEqual({
-				x: 2000,
-				y: 960,
+				x: 1000,
+				y: 500,
 				custom: { intervention: 'Pyrethroid ITN (Only)' }
 			});
 			expect(series.data![1]).toEqual({
-				x: 8000,
-				y: 950,
-				custom: { intervention: 'Pyrethroid ITN (with LSM)' }
+				x: 1200,
+				y: 300,
+				custom: { intervention: 'LSM Only' }
 			});
 		});
 	});
@@ -519,25 +488,8 @@ describe('cases compare config', () => {
 	});
 
 	describe('getCasesCompareConfig integration', () => {
-		const mockCurrentCases: CasesData[] = [
-			{ scenario: 'irs_only', casesPer1000: 10, year: 2 },
-			{ scenario: 'irs_only', casesPer1000: 10, year: 3 }
-		];
-
-		const mockNewCases: CasesData[] = [
-			{ scenario: 'py_only_only', casesPer1000: 20, year: 2 },
-			{ scenario: 'py_only_only', casesPer1000: 20, year: 3 }
-		];
-
 		it('should return a valid Highcharts Options object', () => {
-			const config = getCasesCompareConfig(
-				mockCurrentCases,
-				mockNewCases,
-				mockNewCases,
-				mockPresentFormValues,
-				mockLongTermFormValues,
-				vi.fn()
-			);
+			const config = getCasesCompareConfig(compareTotals, vi.fn());
 
 			expect(config).toBeDefined();
 			expect(config.chart?.type).toBe('line');
@@ -547,14 +499,7 @@ describe('cases compare config', () => {
 		});
 
 		it('should include both Present and Long term series when newCases has data', () => {
-			const config = getCasesCompareConfig(
-				mockCurrentCases,
-				mockNewCases,
-				mockNewCases,
-				mockPresentFormValues,
-				mockLongTermFormValues,
-				vi.fn()
-			);
+			const config = getCasesCompareConfig(compareTotals, vi.fn());
 
 			expect(config.series).toHaveLength(3);
 			expect((config.series as any)[0].name).toBe('Present');
@@ -566,11 +511,7 @@ describe('cases compare config', () => {
 			vi.spyOn(processCases, 'collectPostInterventionCases').mockReturnValue({} as any);
 
 			const config = getCasesCompareConfig(
-				mockCurrentCases,
-				[],
-				[],
-				mockPresentFormValues,
-				mockLongTermFormValues,
+				{ presentTotals: totals, baselineLongTermTotals: {}, fullLongTermTotals: {} },
 				vi.fn()
 			);
 
@@ -579,55 +520,13 @@ describe('cases compare config', () => {
 		});
 
 		it('should apply breaks to xAxis when data points exist', () => {
-			const convertPer1000Spy = vi.spyOn(processCases, 'convertPer1000ToTotal');
-			[960, 900, 850, 700, 650, 600].forEach((value) => {
-				convertPer1000Spy.mockReturnValueOnce(value);
-			});
-			vi.spyOn(processCases, 'collectPostInterventionCases').mockReturnValue({
-				irs_only: mockCurrentCases.filter((c) => c.scenario === 'irs_only'),
-				py_only_only: mockNewCases.filter((c) => c.scenario === 'py_only_only')
-			} as any);
-			vi.spyOn(costs, 'getTotalCostsPerScenario').mockReturnValue({
-				irs_only: 1000,
-				py_only_only: 5000
-			});
-
-			const config = getCasesCompareConfig(
-				mockCurrentCases,
-				mockNewCases,
-				mockNewCases,
-				mockPresentFormValues,
-				mockLongTermFormValues,
-				vi.fn()
-			);
+			const config = getCasesCompareConfig(compareTotals, vi.fn());
 
 			expect((config.xAxis as any).breaks).toBeDefined();
 		});
 
-		it('should pass data to createCasesCompareSeries correctly', () => {
-			getCasesCompareConfig(
-				mockCurrentCases,
-				mockNewCases,
-				mockNewCases,
-				mockPresentFormValues,
-				mockLongTermFormValues,
-				vi.fn()
-			);
-
-			// Verify the function processes the data through helper functions
-			expect(processCases.collectPostInterventionCases).toHaveBeenCalled();
-			expect(costs.getTotalCostsPerScenario).toHaveBeenCalled();
-		});
-
 		it('should set tooltip formatter to createCompareTooltipHtml', () => {
-			const config = getCasesCompareConfig(
-				mockCurrentCases,
-				mockNewCases,
-				mockNewCases,
-				mockPresentFormValues,
-				mockLongTermFormValues,
-				vi.fn()
-			);
+			const config = getCasesCompareConfig(compareTotals, vi.fn());
 
 			expect(config.tooltip?.formatter).toBe(createCompareTooltipHtml);
 		});
@@ -635,14 +534,7 @@ describe('cases compare config', () => {
 		it('line mouseOut should reset all series point states', () => {
 			const setSelectedIntervention = vi.fn();
 
-			const config = getCasesCompareConfig(
-				[],
-				[],
-				[],
-				mockPresentFormValues,
-				mockLongTermFormValues,
-				setSelectedIntervention
-			);
+			const config = getCasesCompareConfig(compareTotals, setSelectedIntervention);
 			const mouseOutHandler = (config.plotOptions as any).line.events.mouseOut;
 
 			const p1 = { setState: vi.fn() };
@@ -662,14 +554,7 @@ describe('cases compare config', () => {
 		it('line click should pass clicked intervention to setSelectedIntervention', () => {
 			const setSelectedIntervention = vi.fn();
 
-			const config = getCasesCompareConfig(
-				[],
-				[],
-				[],
-				mockPresentFormValues,
-				mockLongTermFormValues,
-				setSelectedIntervention
-			);
+			const config = getCasesCompareConfig(compareTotals, setSelectedIntervention);
 			const lineClickHandler = (config.plotOptions as any).line.events.click;
 
 			lineClickHandler.call(
@@ -689,14 +574,7 @@ describe('cases compare config', () => {
 		it('chart click should select closest intervention using setSelectedIntervention', () => {
 			const setSelectedIntervention = vi.fn();
 
-			const config = getCasesCompareConfig(
-				[],
-				[],
-				[],
-				mockPresentFormValues,
-				mockLongTermFormValues,
-				setSelectedIntervention
-			);
+			const config = getCasesCompareConfig(compareTotals, setSelectedIntervention);
 			const clickHandler = (config.chart as any).events.click;
 
 			const pointA = { x: 1000, options: { custom: { intervention: 'IRS Only' } } };

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -9,8 +9,8 @@ import {
 	getClosestPoint
 } from '$lib/charts/casesConfig';
 import * as processCases from '$lib/process-results/processCases';
+import type { CompareTotals } from '$lib/types/compare';
 import type { Scenario } from '$lib/types/userState';
-import type { CompareTotals } from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import type { PointOptionsObject } from 'highcharts';
 import { describe, expect, it } from 'vitest';
 describe('getCasesConfig', () => {
@@ -210,7 +210,7 @@ describe('cases compare config', () => {
 			totalCases: 300
 		}
 	};
-	const compareTotals = {
+	const compareTotals: CompareTotals = {
 		presentTotals: totals,
 		baselineLongTermTotals: totals,
 		fullLongTermTotals: totals

--- a/client/src/tests/lib/charts/prevalenceConfig.spec.ts
+++ b/client/src/tests/lib/charts/prevalenceConfig.spec.ts
@@ -149,6 +149,12 @@ describe('getPrevalenceConfig', () => {
 });
 
 describe('getPrevalenceConfigCompare', () => {
+	const emulatorResults = {
+		prevalence: [
+			{ scenario: 'irs_only', days: 365, prevalence: 0.15 },
+			{ scenario: 'py_only_only', days: 365, prevalence: 0.12 }
+		]
+	} as any;
 	it('createComparisonSeries should create filtered series by selected intervention', () => {
 		const mockData: PrevalenceData[] = [
 			{ scenario: 'irs_only', days: 365, prevalence: 0.15 },
@@ -166,14 +172,12 @@ describe('getPrevalenceConfigCompare', () => {
 	});
 
 	it('should create series for each time frame', () => {
-		const prevalence: PrevalenceData[] = [
-			{ scenario: 'irs_only', days: 365, prevalence: 0.15 },
-			{ scenario: 'py_only_only', days: 365, prevalence: 0.12 }
-		];
-
 		const selectedSeries = 'Pyrethroid ITN (Only)';
 
-		const config = getPrevalenceConfigCompare(prevalence, prevalence, prevalence, selectedSeries);
+		const config = getPrevalenceConfigCompare(
+			{ present: emulatorResults, baselineLongTerm: emulatorResults, fullLongTerm: emulatorResults },
+			selectedSeries
+		);
 		const series = config.series as Highcharts.SeriesSplineOptions[];
 
 		expect(series).toHaveLength(3);
@@ -183,19 +187,28 @@ describe('getPrevalenceConfigCompare', () => {
 	});
 
 	it('should handle empty long term data', () => {
-		const prevalence: PrevalenceData[] = [
-			{ scenario: 'irs_only', days: 365, prevalence: 0.15 },
-			{ scenario: 'py_only_only', days: 365, prevalence: 0.12 }
-		];
-
-		const config = getPrevalenceConfigCompare(prevalence, [], [], 'Pyrethroid ITN (Only)');
+		const config = getPrevalenceConfigCompare(
+			{
+				present: emulatorResults,
+				baselineLongTerm: { prevalence: [] } as any,
+				fullLongTerm: { prevalence: [] } as any
+			},
+			'Pyrethroid ITN (Only)'
+		);
 		const series = config.series as Highcharts.SeriesSplineOptions[];
 
 		expect(series).toHaveLength(1);
 		expect(series[0].name).toBe('Present');
 	});
 	it('should have selected intervention in title', () => {
-		const config = getPrevalenceConfigCompare([], [], [], 'Pyrethroid ITN (Only)');
+		const config = getPrevalenceConfigCompare(
+			{
+				present: emulatorResults,
+				baselineLongTerm: emulatorResults,
+				fullLongTerm: emulatorResults
+			},
+			'Pyrethroid ITN (Only)'
+		);
 
 		expect(config.title?.text).toContain('Pyrethroid ITN (Only)');
 	});

--- a/client/src/tests/lib/tables/compareCasesTable.spec.ts
+++ b/client/src/tests/lib/tables/compareCasesTable.spec.ts
@@ -1,0 +1,138 @@
+import { renderComponent } from '$lib/components/ui/data-table';
+import {
+	buildCompareCasesTableData,
+	compareCasesTableColumns,
+	getCasesCell,
+	getCasesHeader,
+	getCostsHeader,
+	getScenarioKeys
+} from '$lib/tables/compareCasesTable';
+
+vi.mock('$lib/charts/baseChart', () => ({
+	ScenarioToLabel: {
+		baseline: 'Baseline',
+		intervention: 'Intervention'
+	}
+}));
+
+vi.mock('$lib/components/data-table/DataTableSortHeader.svelte', () => ({
+	default: 'DataTableSortHeader'
+}));
+
+vi.mock('$lib/components/ui/data-table', () => ({
+	renderComponent: vi.fn(() => 'rendered-header')
+}));
+
+describe('compareCasesTable', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('getScenarioKeys returns unique scenarios preserving first-seen order', () => {
+		const keys = getScenarioKeys(
+			{ baseline: { totalCost: 1, totalCases: 2 } } as any,
+			{ intervention: { totalCost: 3, totalCases: 4 }, baseline: { totalCost: 5, totalCases: 6 } } as any,
+			{ intervention: { totalCost: 7, totalCases: 8 } } as any
+		);
+
+		expect(keys).toEqual(['baseline', 'intervention']);
+	});
+
+	it('buildCompareCasesTableData merges totals across all timeframes', () => {
+		const data = buildCompareCasesTableData({
+			presentTotals: {
+				baseline: { totalCost: 100, totalCases: 10 }
+			},
+			baselineLongTermTotals: {
+				baseline: { totalCost: 200, totalCases: 20 },
+				intervention: { totalCost: 300, totalCases: 30 }
+			},
+			fullLongTermTotals: {
+				intervention: { totalCost: 400, totalCases: 40 }
+			}
+		} as any);
+
+		expect(data).toEqual([
+			{
+				intervention: 'Baseline',
+				presentCost: 100,
+				presentCases: 10,
+				longTermBaselineCost: 200,
+				longTermBaselineCases: 20,
+				fullLongTermCost: undefined,
+				fullLongTermCases: undefined
+			},
+			{
+				intervention: 'Intervention',
+				presentCost: undefined,
+				presentCases: undefined,
+				longTermBaselineCost: 300,
+				longTermBaselineCases: 30,
+				fullLongTermCost: 400,
+				fullLongTermCases: 40
+			}
+		]);
+	});
+
+	it('getCasesCell formats numeric values and handles undefined', () => {
+		const cell = getCasesCell().cell;
+		expect(cell({ getValue: () => 1200 } as any)).toBe('1,200');
+		expect(cell({ getValue: () => undefined } as any)).toBe('-');
+	});
+
+	it('getCasesHeader uses sortable header renderer with Cases label', () => {
+		const onClick = vi.fn();
+		const result = getCasesHeader().header({
+			column: { getToggleSortingHandler: () => onClick }
+		} as any);
+
+		expect(result).toBe('rendered-header');
+		expect(renderComponent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				onclick: onClick,
+				label: 'Cases'
+			})
+		);
+	});
+
+	it('getCostsHeader uses sortable header renderer with Cost label', () => {
+		const onClick = vi.fn();
+		const result = getCostsHeader().header({
+			column: { getToggleSortingHandler: () => onClick }
+		} as any);
+
+		expect(result).toBe('rendered-header');
+		expect(renderComponent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				onclick: onClick,
+				label: 'Cost'
+			})
+		);
+	});
+
+	it('compareCasesTableColumns contains expected top-level groups', () => {
+		expect(compareCasesTableColumns.map((c: any) => c.header)).toEqual([
+			'Intervention',
+			'Present',
+			'Long term (baseline only)',
+			'Long term (baseline + control strategy)'
+		]);
+	});
+
+	it('present cost cell formats as USD currency and supports undefined', () => {
+		const presentGroup: any = compareCasesTableColumns.find((c: any) => c.accessorKey === 'present');
+		const presentCostCol = presentGroup.columns.find((c: any) => c.accessorKey === 'presentCost');
+
+		expect(presentCostCol.cell({ getValue: () => 1200 } as any)).toBe('$1,200');
+		expect(presentCostCol.cell({ getValue: () => undefined } as any)).toBe('-');
+	});
+
+	it('intervention leaf column returns raw intervention label', () => {
+		const interventionGroup: any = compareCasesTableColumns.find((c: any) => c.accessorKey === 'intervention');
+		const leaf = interventionGroup.columns[0];
+
+		expect(leaf.cell({ getValue: () => 'Baseline' } as any)).toBe('Baseline');
+	});
+});

--- a/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
@@ -1,8 +1,8 @@
 import { MOCK_CASES_DATA, MOCK_FORM_VALUES, MOCK_PREVALENCE_DATA } from '$mocks/mocks';
-import ComparePlots from '$routes/projects/[project]/regions/[region]/compare/_components/Plots.svelte';
+import ComparePlots from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import { render } from 'vitest-browser-svelte';
 
-describe('Compare plots component', () => {
+describe('Compare CompareResults component', () => {
 	it('should render graphs with present and long term results', async () => {
 		const screen = render(ComparePlots, {
 			props: {

--- a/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
@@ -3,32 +3,37 @@ import ComparePlots from '$routes/projects/[project]/regions/[region]/compare/_c
 import { render } from 'vitest-browser-svelte';
 
 describe('Compare CompareResults component', () => {
-	it('should render graphs with present and long term results', async () => {
+	it('should render graphs & table with present and long term results', async () => {
 		const screen = render(ComparePlots, {
 			props: {
 				chartTheme: 'highcharts-dark',
-				presentResults: {
-					cases: MOCK_CASES_DATA,
-					prevalence: MOCK_PREVALENCE_DATA,
-					eirValid: true
+				results: {
+					present: {
+						cases: MOCK_CASES_DATA,
+						prevalence: MOCK_PREVALENCE_DATA,
+						eirValid: true
+					},
+					fullLongTerm: {
+						cases: MOCK_CASES_DATA,
+						prevalence: MOCK_PREVALENCE_DATA,
+						eirValid: true
+					},
+					baselineLongTerm: {
+						cases: MOCK_CASES_DATA,
+						prevalence: MOCK_PREVALENCE_DATA,
+						eirValid: true
+					}
 				},
-				fullLongTermResults: {
-					cases: MOCK_CASES_DATA,
-					prevalence: MOCK_PREVALENCE_DATA,
-					eirValid: true
-				},
-				baselineLongTermResults: {
-					cases: MOCK_CASES_DATA,
-					prevalence: MOCK_PREVALENCE_DATA,
-					eirValid: true
-				},
-				presentFormValues: MOCK_FORM_VALUES,
-				longTermFormValues: MOCK_FORM_VALUES
+				formValues: {
+					presentFormValues: MOCK_FORM_VALUES,
+					longTermFormValues: MOCK_FORM_VALUES
+				}
 			}
 		} as any);
 
 		await expect.element(screen.getByRole('region', { name: 'prevalence compare graph' })).toBeVisible();
 		await expect.element(screen.getByRole('region', { name: 'cases compare graph' })).toBeVisible();
+		await expect.element(screen.getByRole('table')).toBeVisible();
 
 		const presentLegendLabels = screen.getByRole('button', { name: 'Show Present' }).all();
 		const baselineLongTermLegendLabels = screen.getByRole('button', { name: 'Show Long Term (baseline only)' }).all();


### PR DESCRIPTION
The following adds a table to the compare page. the data is the same as the first cases plot. The only exception is we show every intervention and dont filter any unoptimal ones out. There is also some small refactors as the data for the chart and table are both very similar. Ive commented some bits of refactor to help review.

Testing:
ensure long term toggle is checked. then run a region wth interventions. The head to long term region page and play around to see the table in action. The cost/cases should match up with the graph

<img width="1004" height="502" alt="image" src="https://github.com/user-attachments/assets/ed39118d-5550-428b-a785-5a2b05d09066" />
