### PR TITLE
Longterm compare 2.3

### DIFF
--- a/client/e2e/compare.test.ts
+++ b/client/e2e/compare.test.ts
@@ -72,7 +72,7 @@ test.describe('E2E Compare Page', () => {
 		await runRegionWithItn(page);
 		await page.getByRole('link', { name: 'Long term planning' }).click();
 
-		await page.getByRole('tab', { name: 'Table ' }).click();
+		await page.getByRole('tab', { name: 'Table' }).click();
 		await expect(page.getByRole('table')).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: 'Intervention' })).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: 'Long term (baseline only)' })).toBeVisible();

--- a/client/e2e/compare.test.ts
+++ b/client/e2e/compare.test.ts
@@ -68,25 +68,11 @@ test.describe('E2E Compare Page', () => {
 		await expect(casesPlot.getByRole('button', { name: 'Show Present' })).toBeVisible();
 	});
 
-	test('should be able to click on cases plot and see prevalence plot for that intervention', async ({ page }) => {
-		await runRegionWithItn(page);
-		await page.getByRole('link', { name: 'Long term planning' }).click();
-
-		// initial is no intervention plot
-		await expect(page.getByText('Prevalence in under 5 year olds - No Intervention').first()).toBeVisible();
-
-		// click on cases x value is 54 thousand something (exact value may change based on emulator result)
-		await page.getByRole('img', { name: 'x, 54', exact: false }).click();
-
-		await expect(
-			page.getByLabel('prevalence compare graph').getByText('Pyrethroid ITN (Only)', { exact: true })
-		).toBeVisible();
-	});
-
 	test('should render table with cost and cases for time frames', async ({ page }) => {
 		await runRegionWithItn(page);
 		await page.getByRole('link', { name: 'Long term planning' }).click();
 
+		await page.getByRole('tab', { name: 'Table ' }).click();
 		await expect(page.getByRole('table')).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: 'Intervention' })).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: 'Long term (baseline only)' })).toBeVisible();

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -182,10 +182,11 @@ export const getClosestPoint = (cost: number, allSeries: Highcharts.Series[]): H
 			return Math.abs((point.x as number) - cost) < Math.abs((closest.x as number) - cost) ? point : closest;
 		}, null);
 
-export const getCasesCompareConfig = (
-	{ presentTotals, baselineLongTermTotals, fullLongTermTotals }: CompareTotals,
-	setSelectedIntervention: (intervention: ScenarioLabel) => void
-): Options => {
+export const getCasesCompareConfig = ({
+	presentTotals,
+	baselineLongTermTotals,
+	fullLongTermTotals
+}: CompareTotals): Options => {
 	const presentSeries = createCasesCompareSeries(presentTotals, 'Present');
 	const baselineLongTermSeries = createCasesCompareSeries(baselineLongTermTotals, 'Long term (baseline only)');
 	const fullLongTermSeries = createCasesCompareSeries(fullLongTermTotals, 'Long term (baseline + control strategy)');
@@ -195,14 +196,7 @@ export const getCasesCompareConfig = (
 	return {
 		chart: {
 			type: 'line',
-			height: 450,
-			events: {
-				click: function (event) {
-					const xValue = Math.round((event as Highcharts.ChartClickEventObject).xAxis[0].value);
-					const closestPoint = getClosestPoint(xValue, this.series);
-					if (closestPoint) setSelectedIntervention(closestPoint.options.custom!.intervention);
-				}
-			}
+			height: 450
 		},
 		title: {
 			text: 'Present vs Long term - Total Cases vs Total Cost'
@@ -214,7 +208,7 @@ export const getCasesCompareConfig = (
 			}
 		},
 		caption: {
-			text: '1. Suboptimal interventions are not plotted; view the table to see them. <br/> 2. Click on graph to view prevalence across all timeframes for that intervention strategy.',
+			text: 'Suboptimal interventions are not plotted; view the table to see them.',
 			align: 'left',
 			verticalAlign: 'bottom',
 			style: {
@@ -246,9 +240,6 @@ export const getCasesCompareConfig = (
 				events: {
 					mouseOut: function () {
 						resetSeriesPointStates(this.chart.series);
-					},
-					click: function (event) {
-						setSelectedIntervention(event.point.options.custom!.intervention);
 					}
 				}
 			}

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -3,7 +3,7 @@ import { type CasesAverted, type ScenarioTotals } from '$lib/process-results/pro
 import type { CompareTotals } from '$lib/types/compare';
 import type { Scenario } from '$lib/types/userState';
 import { type Options, type PointOptionsObject, type SeriesColumnOptions, type SeriesLineOptions } from 'highcharts';
-import { getColumnFill, ScenarioToLabel, type ScenarioLabel } from './baseChart';
+import { getColumnFill, ScenarioToLabel } from './baseChart';
 
 const getCasesSeriesData = (
 	casesAverted: Partial<Record<Scenario, CasesAverted>>

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -214,7 +214,7 @@ export const getCasesCompareConfig = (
 			}
 		},
 		caption: {
-			text: 'Click on graph to view prevalence across all timeframes for that intervention strategy',
+			text: '1. Suboptimal interventions are not plotted; view the table to see them. <br/> 2. Click on graph to view prevalence across all timeframes for that intervention strategy.',
 			align: 'left',
 			verticalAlign: 'bottom',
 			style: {

--- a/client/src/lib/components/SliderWithMarker.svelte
+++ b/client/src/lib/components/SliderWithMarker.svelte
@@ -29,7 +29,7 @@
 
 <FieldWithChange {value} baseline={markerValue} postfixUnit={unit} {fractionalDigits}>
 	<div class={cn('relative h-7 flex-1', containerClass)}>
-		<Slider bind:value={value as never} class={className} {min} {max} {...restProps} />
+		<Slider bind:value={value as never} class={className} {min} {max} {...restProps} renderThumbLabels />
 		<div class="pointer-events-none absolute top-0 h-full" style="left: {markerPos}%;">
 			<div class="z-1.5 h-full w-0.5 bg-foreground/80"></div>
 			<div class="-translate-x-1/4 text-xs text-muted-foreground">

--- a/client/src/lib/components/ui/slider/slider.svelte
+++ b/client/src/lib/components/ui/slider/slider.svelte
@@ -8,8 +8,12 @@
 		orientation = 'horizontal',
 		class: className,
 		thumbClass = '',
+		renderThumbLabels = false,
 		...restProps
-	}: WithoutChildrenOrChild<SliderPrimitive.RootProps> & { thumbClass?: string } = $props();
+	}: WithoutChildrenOrChild<SliderPrimitive.RootProps> & {
+		thumbClass?: string;
+		renderThumbLabels?: boolean;
+	} = $props();
 </script>
 
 <!--
@@ -49,6 +53,11 @@ get along, so we shut typescript up by casting `value` to `never`.
 					thumbClass
 				)}
 			/>
+			{#if renderThumbLabels}
+				<SliderPrimitive.ThumbLabel {index} position="top" class="text-xs">
+					{value}
+				</SliderPrimitive.ThumbLabel>
+			{/if}
 		{/each}
 	{/snippet}
 </SliderPrimitive.Root>

--- a/client/src/lib/components/ui/table/table-head.svelte
+++ b/client/src/lib/components/ui/table/table-head.svelte
@@ -8,6 +8,7 @@
 <th
 	bind:this={ref}
 	data-slot="table-head"
+	scope="col"
 	class={cn(
 		'h-10 bg-clip-padding px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0',
 		className

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -124,17 +124,14 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	}
 ];
 
-export const getScenarioKeys = (...totalsByTImeFrames: Partial<Record<Scenario, ScenarioTotals>>[]): Scenario[] =>
-	Array.from(new Set(totalsByTImeFrames.flatMap((summary) => Object.keys(summary) as Scenario[])));
+export const getScenarioKeys = (...totalsByTimeFrames: Partial<Record<Scenario, ScenarioTotals>>[]): Scenario[] =>
+	Array.from(new Set(totalsByTimeFrames.flatMap((summary) => Object.keys(summary) as Scenario[])));
 
-export const buildCompareCasesTableData = ({
-	presentTotals,
-	baselineLongTermTotals,
-	fullLongTermTotals
-}: CompareTotals): ComparisonTimeFramesData[] => {
-	const scenarios = getScenarioKeys(presentTotals, baselineLongTermTotals, fullLongTermTotals);
-
-	return scenarios.map((scenario) => ({
+export const buildCompareCasesTableData = (
+	{ presentTotals, baselineLongTermTotals, fullLongTermTotals }: CompareTotals,
+	scenarios: Scenario[]
+): ComparisonTimeFramesData[] =>
+	scenarios.map((scenario) => ({
 		intervention: ScenarioToLabel[scenario as Scenario],
 		presentCost: presentTotals[scenario as Scenario]?.totalCost,
 		presentCases: presentTotals[scenario as Scenario]?.totalCases,
@@ -143,4 +140,3 @@ export const buildCompareCasesTableData = ({
 		fullLongTermCost: fullLongTermTotals[scenario as Scenario]?.totalCost,
 		fullLongTermCases: fullLongTermTotals[scenario as Scenario]?.totalCases
 	}));
-};

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -1,9 +1,11 @@
 import { ScenarioToLabel } from '$lib/charts/baseChart';
 import DataTableSortHeader from '$lib/components/data-table/DataTableSortHeader.svelte';
-import { renderComponent } from '$lib/components/ui/data-table';
+import { renderComponent, renderSnippet } from '$lib/components/ui/data-table';
+import { roundNumber } from '$lib/number';
 import type { CompareTotals } from '$lib/types/compare';
 import type { Scenario } from '$lib/types/userState';
 import type { CellContext, ColumnDef, HeaderContext } from '@tanstack/table-core';
+import { createRawSnippet } from 'svelte';
 
 export interface ComparisonTimeFramesData {
 	intervention: string;
@@ -24,17 +26,36 @@ export const getCasesHeader = () => ({
 	}
 });
 
+export const casesCellSnippet = createRawSnippet<[{ value: number; percentageChange: number }]>((getProps) => {
+	const { value, percentageChange } = getProps();
+	const formatter = new Intl.NumberFormat('en-US', {
+		style: 'decimal',
+		trailingZeroDisplay: 'stripIfInteger',
+		maximumFractionDigits: 0
+	});
+	const percentageChangeText = percentageChange ? ` (${percentageChange >= 0 ? '+' : ''}${percentageChange}%)` : '';
+	return {
+		render: () =>
+			`<span>${formatter.format(value)}<span class="text-xs text-muted-foreground">${percentageChangeText}</span></span>`
+	};
+});
+
 export const getCasesCell = () => ({
-	cell: ({ getValue }: CellContext<ComparisonTimeFramesData, number | undefined>) => {
+	cell: ({ getValue, row, column }: CellContext<ComparisonTimeFramesData, number | undefined>) => {
 		const cellValue = getValue();
 		if (cellValue === undefined) return '-';
 
-		const formatter = new Intl.NumberFormat('en-US', {
-			style: 'decimal',
-			trailingZeroDisplay: 'stripIfInteger',
-			maximumFractionDigits: 0
+		let percentageChange = 0;
+		if (column.id !== 'presentCases') {
+			const presentCases = row.getValue('presentCases') as number;
+			if (presentCases) {
+				percentageChange = roundNumber(((cellValue - presentCases) / presentCases) * 100, 0);
+			}
+		}
+		return renderSnippet(casesCellSnippet, {
+			value: cellValue,
+			percentageChange
 		});
-		return formatter.format(cellValue);
 	}
 });
 

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -1,7 +1,6 @@
 import { ScenarioToLabel } from '$lib/charts/baseChart';
 import DataTableSortHeader from '$lib/components/data-table/DataTableSortHeader.svelte';
 import { renderComponent } from '$lib/components/ui/data-table';
-import { type ScenarioTotals } from '$lib/process-results/processCases';
 import type { CompareTotals } from '$lib/types/compare';
 import type { Scenario } from '$lib/types/userState';
 import type { CellContext, ColumnDef, HeaderContext } from '@tanstack/table-core';
@@ -123,9 +122,6 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 		]
 	}
 ];
-
-export const getScenarioKeys = (...totalsByTimeFrames: Partial<Record<Scenario, ScenarioTotals>>[]): Scenario[] =>
-	Array.from(new Set(totalsByTimeFrames.flatMap((summary) => Object.keys(summary) as Scenario[])));
 
 export const buildCompareCasesTableData = (
 	{ presentTotals, baselineLongTermTotals, fullLongTermTotals }: CompareTotals,

--- a/client/src/lib/types/compare.ts
+++ b/client/src/lib/types/compare.ts
@@ -6,11 +6,13 @@ export interface CompareParameter {
 	label: string;
 	min: number;
 	max: number;
+	step: number;
 }
 
 export interface InterventionCompareCost {
 	costName: string;
 	costLabel: string;
+	step: number;
 }
 export interface InterventionCompareParameter extends CompareParameter {
 	linkedCosts: InterventionCompareCost[];

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
@@ -68,7 +68,7 @@
 </script>
 
 <div class="grid grid-cols-4 gap-4">
-	<div class="col-span-1 flex flex-1/4 flex-col gap-6 rounded-md border p-4">
+	<div class="col-span-1 flex flex-col gap-6 rounded-md border p-4">
 		<Field.Group class="gap-4">
 			<Field.Field>
 				<Field.Label for="parameter-select">What do you want to adjust?</Field.Label>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
 	import { DEBOUNCE_DELAY_MS } from '$lib/components/dynamic-region-form/utils';
-	import Loader from '$lib/components/Loader.svelte';
 	import SliderWithMarker from '$lib/components/SliderWithMarker.svelte';
 	import * as Field from '$lib/components/ui/field';
 	import * as RadioGroup from '$lib/components/ui/radio-group';
@@ -11,8 +10,8 @@
 	import { onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import { runCompareEmulator } from '../utils';
-	import InterventionFields from './InterventionFields.svelte';
 	import CompareResults from './CompareResults.svelte';
+	import InterventionFields from './InterventionFields.svelte';
 
 	interface Props {
 		presentResults: EmulatorResults;

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
@@ -68,8 +68,8 @@
 	});
 </script>
 
-<div class="flex flex-row gap-4">
-	<div class="flex w-1/4 flex-col gap-6 rounded-md border p-4">
+<div class="grid grid-cols-4 gap-4">
+	<div class="col-span-1 flex flex-1/4 flex-col gap-6 rounded-md border p-4">
 		<Field.Group class="gap-4">
 			<Field.Field>
 				<Field.Label for="parameter-select">What do you want to adjust?</Field.Label>
@@ -114,7 +114,7 @@
 	</div>
 
 	{#if isLoading}
-		<div class="flex h-[500px] flex-3/4 items-center justify-center">
+		<div class="col-span-3 flex h-[500px] items-center justify-center">
 			<Loader text="Loading..." />
 		</div>
 	{:else}

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
@@ -85,7 +85,7 @@
 					{/each}
 				</RadioGroup.Root>
 			</Field.Field>
-			<Field.Field>
+			<Field.Field class="gap-3.5">
 				<Field.Label for="baseline-parameter-slider">Change from baseline (%)</Field.Label>
 				<SliderWithMarker
 					id="baseline-parameter-slider"

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
@@ -95,6 +95,7 @@
 					onValueChange={(value: number) => onSliderChange(value, selectedBaselineParameter.parameterName)}
 					max={selectedBaselineParameter.max}
 					min={selectedBaselineParameter.min}
+					step={selectedBaselineParameter.step}
 					disabled={isLoading}
 					aria-label="Adjust baseline parameter slider"
 					markerValue={presentFormValues[selectedBaselineParameter.parameterName] as number}
@@ -112,23 +113,17 @@
 			{onSliderChange}
 		/>
 	</div>
-
-	{#if isLoading}
-		<div class="col-span-3 flex h-[500px] items-center justify-center">
-			<Loader text="Loading..." />
-		</div>
-	{:else}
-		<CompareResults
-			{chartTheme}
-			results={{
-				present: presentResults,
-				fullLongTerm: fullLongTermResults,
-				baselineLongTerm: baselineLongTermResults
-			}}
-			formValues={{
-				presentFormValues,
-				longTermFormValues
-			}}
-		/>
-	{/if}
+	<CompareResults
+		{isLoading}
+		{chartTheme}
+		results={{
+			present: presentResults,
+			fullLongTerm: fullLongTermResults,
+			baselineLongTerm: baselineLongTermResults
+		}}
+		formValues={{
+			presentFormValues,
+			longTermFormValues
+		}}
+	/>
 </div>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -39,6 +39,7 @@
 	let scenarios = $derived(
 		getScenariosFromTotals(totals.presentTotals, totals.baselineLongTermTotals, totals.fullLongTermTotals)
 	);
+	let selectedTab = $state<'graph' | 'table'>('graph');
 	let tableData = $derived(buildCompareCasesTableData(totals, scenarios));
 	let prevalenceConfig = $derived(getPrevalenceConfigCompare(results, selectedIntervention));
 </script>
@@ -50,7 +51,7 @@
 {:else}
 	<div class="col-span-3 flex flex-col gap-4">
 		<!-- Cases -->
-		<Tabs.Root value="graph">
+		<Tabs.Root bind:value={selectedTab}>
 			<div class="flex gap-2">
 				<Tabs.List class="w-full">
 					<Tabs.Trigger value="graph">Graph</Tabs.Trigger>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -31,19 +31,18 @@
 		),
 		fullLongTermTotals: getTotalCasesAndCostsPerScenario(results.fullLongTerm.cases, formValues.longTermFormValues)
 	});
+
+	let selectedIntervention = $state<ScenarioLabel>('No Intervention');
+	let casesConfig = $derived(getCasesCompareConfig(totals));
+
 	let scenarios = $derived(
 		getScenarioKeys(totals.presentTotals, totals.baselineLongTermTotals, totals.fullLongTermTotals)
 	);
-
-	let selectedIntervention = $state<ScenarioLabel>('No Intervention');
-	let casesConfig = $derived(getCasesCompareConfig(totals, (intervention) => (selectedIntervention = intervention)));
-
 	let tableData = $derived(buildCompareCasesTableData(totals, scenarios));
-
 	let prevalenceConfig = $derived(getPrevalenceConfigCompare(results, selectedIntervention));
 </script>
 
-<div class="flex flex-3/4 flex-col gap-4">
+<div class="col-span-3 flex flex-col gap-4">
 	<Tabs.Root value="graph">
 		<div class="flex gap-2">
 			<Tabs.List class="w-full">
@@ -62,13 +61,13 @@
 	</Tabs.Root>
 	<div class="flex flex-col gap-2">
 		<Label>Select intervention to compare prevalence across timeframes:</Label>
-		<RadioGroup.Root class="flex w-full items-center space-x-1" bind:value={selectedIntervention}>
+		<RadioGroup.Root class="flex flex-wrap items-center" bind:value={selectedIntervention}>
 			{#each scenarios as scenario}
 				<div>
 					<RadioGroup.Item value={ScenarioToLabel[scenario]} id={scenario} class="peer sr-only" />
 					<Label
 						for={scenario}
-						class="flex cursor-pointer items-center rounded-md border p-2.5 text-xs peer-data-[state=checked]:border-primary hover:bg-accent"
+						class="flex cursor-pointer items-center rounded-md border p-2.5 text-xs peer-data-[state=checked]:border-primary hover:bg-accent "
 					>
 						{ScenarioToLabel[scenario]}
 					</Label>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -70,7 +70,7 @@
 		<div class="flex flex-col gap-2">
 			<Label>Select intervention to compare prevalence across timeframes:</Label>
 			<RadioGroup.Root class="flex flex-wrap items-center" bind:value={selectedIntervention}>
-				{#each scenarios as scenario}
+				{#each scenarios as scenario (scenario)}
 					<div>
 						<RadioGroup.Item value={ScenarioToLabel[scenario]} id={scenario} class="peer sr-only" />
 						<Label

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -49,6 +49,7 @@
 	</div>
 {:else}
 	<div class="col-span-3 flex flex-col gap-4">
+		<!-- Cases -->
 		<Tabs.Root value="graph">
 			<div class="flex gap-2">
 				<Tabs.List class="w-full">
@@ -65,6 +66,7 @@
 				<DataTable data={tableData} columns={compareCasesTableColumns} />
 			</Tabs.Content>
 		</Tabs.Root>
+		<!-- Prevalence -->
 		<div class="flex flex-col gap-2">
 			<Label>Select intervention to compare prevalence across timeframes:</Label>
 			<RadioGroup.Root class="flex flex-wrap items-center" bind:value={selectedIntervention}>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -4,14 +4,14 @@
 	import { getPrevalenceConfigCompare } from '$lib/charts/prevalenceConfig';
 	import DataTable from '$lib/components/data-table/DataTable.svelte';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
-	import { getTotalCasesAndCostsPerScenario } from '$lib/process-results/processCases';
-	import { buildCompareCasesTableData, compareCasesTableColumns, getScenarioKeys } from '$lib/tables/compareCasesTable';
-	import type { CompareResults } from '$lib/types/compare';
-	import * as Tabs from '$lib/components/ui/tabs/index.js';
-	import type { Scenario } from '$lib/types/userState';
-	import * as RadioGroup from '$lib/components/ui/radio-group/index.js';
+	import Loader from '$lib/components/Loader.svelte';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import { Root } from '$lib/components/ui/button';
+	import * as RadioGroup from '$lib/components/ui/radio-group/index.js';
+	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import { getTotalCasesAndCostsPerScenario } from '$lib/process-results/processCases';
+	import { buildCompareCasesTableData, compareCasesTableColumns } from '$lib/tables/compareCasesTable';
+	import type { CompareResults } from '$lib/types/compare';
+	import { getScenariosFromTotals } from '../utils';
 
 	interface Props {
 		chartTheme: string;
@@ -20,8 +20,9 @@
 			presentFormValues: Record<string, FormValue>;
 			longTermFormValues: Record<string, FormValue>;
 		};
+		isLoading: boolean;
 	}
-	let { chartTheme, results, formValues }: Props = $props();
+	let { chartTheme, results, formValues, isLoading }: Props = $props();
 
 	let totals = $derived({
 		presentTotals: getTotalCasesAndCostsPerScenario(results.present.cases, formValues.presentFormValues),
@@ -36,46 +37,52 @@
 	let casesConfig = $derived(getCasesCompareConfig(totals));
 
 	let scenarios = $derived(
-		getScenarioKeys(totals.presentTotals, totals.baselineLongTermTotals, totals.fullLongTermTotals)
+		getScenariosFromTotals(totals.presentTotals, totals.baselineLongTermTotals, totals.fullLongTermTotals)
 	);
 	let tableData = $derived(buildCompareCasesTableData(totals, scenarios));
 	let prevalenceConfig = $derived(getPrevalenceConfigCompare(results, selectedIntervention));
 </script>
 
-<div class="col-span-3 flex flex-col gap-4">
-	<Tabs.Root value="graph">
-		<div class="flex gap-2">
-			<Tabs.List class="w-full">
-				<Tabs.Trigger value="graph">Graph</Tabs.Trigger>
-				<Tabs.Trigger value="table">Table</Tabs.Trigger>
-			</Tabs.List>
-		</div>
-		<Tabs.Content value="graph">
-			<section aria-label="cases compare graph" class="rounded-lg border p-2">
-				<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
-			</section>
-		</Tabs.Content>
-		<Tabs.Content value="table">
-			<DataTable data={tableData} columns={compareCasesTableColumns} />
-		</Tabs.Content>
-	</Tabs.Root>
-	<div class="flex flex-col gap-2">
-		<Label>Select intervention to compare prevalence across timeframes:</Label>
-		<RadioGroup.Root class="flex flex-wrap items-center" bind:value={selectedIntervention}>
-			{#each scenarios as scenario}
-				<div>
-					<RadioGroup.Item value={ScenarioToLabel[scenario]} id={scenario} class="peer sr-only" />
-					<Label
-						for={scenario}
-						class="flex cursor-pointer items-center rounded-md border p-2.5 text-xs peer-data-[state=checked]:border-primary hover:bg-accent "
-					>
-						{ScenarioToLabel[scenario]}
-					</Label>
-				</div>
-			{/each}
-		</RadioGroup.Root>
-		<section aria-label="prevalence compare graph" class="rounded-lg border p-2">
-			<div {@attach createHighchart(prevalenceConfig)} class={chartTheme}></div>
-		</section>
+{#if isLoading}
+	<div class="col-span-3 flex h-[500px] items-center justify-center">
+		<Loader text="Loading..." />
 	</div>
-</div>
+{:else}
+	<div class="col-span-3 flex flex-col gap-4">
+		<Tabs.Root value="graph">
+			<div class="flex gap-2">
+				<Tabs.List class="w-full">
+					<Tabs.Trigger value="graph">Graph</Tabs.Trigger>
+					<Tabs.Trigger value="table">Table</Tabs.Trigger>
+				</Tabs.List>
+			</div>
+			<Tabs.Content value="graph">
+				<section aria-label="cases compare graph" class="rounded-lg border p-2">
+					<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
+				</section>
+			</Tabs.Content>
+			<Tabs.Content value="table">
+				<DataTable data={tableData} columns={compareCasesTableColumns} />
+			</Tabs.Content>
+		</Tabs.Root>
+		<div class="flex flex-col gap-2">
+			<Label>Select intervention to compare prevalence across timeframes:</Label>
+			<RadioGroup.Root class="flex flex-wrap items-center" bind:value={selectedIntervention}>
+				{#each scenarios as scenario}
+					<div>
+						<RadioGroup.Item value={ScenarioToLabel[scenario]} id={scenario} class="peer sr-only" />
+						<Label
+							for={scenario}
+							class="flex cursor-pointer items-center rounded-md border p-2 text-xs not-peer-data-[state=checked]:text-muted-foreground peer-data-[state=checked]:border-primary hover:bg-accent"
+						>
+							{ScenarioToLabel[scenario]}
+						</Label>
+					</div>
+				{/each}
+			</RadioGroup.Root>
+			<section aria-label="prevalence compare graph" class="rounded-lg border p-2">
+				<div {@attach createHighchart(prevalenceConfig)} class={chartTheme}></div>
+			</section>
+		</div>
+	</div>
+{/if}

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
-	import { createHighchart, type ScenarioLabel } from '$lib/charts/baseChart';
+	import { createHighchart, ScenarioToLabel, type ScenarioLabel } from '$lib/charts/baseChart';
 	import { getCasesCompareConfig } from '$lib/charts/casesConfig';
 	import { getPrevalenceConfigCompare } from '$lib/charts/prevalenceConfig';
 	import DataTable from '$lib/components/data-table/DataTable.svelte';
 	import type { FormValue } from '$lib/components/dynamic-region-form/types';
 	import { getTotalCasesAndCostsPerScenario } from '$lib/process-results/processCases';
-	import { buildCompareCasesTableData, compareCasesTableColumns } from '$lib/tables/compareCasesTable';
+	import { buildCompareCasesTableData, compareCasesTableColumns, getScenarioKeys } from '$lib/tables/compareCasesTable';
 	import type { CompareResults } from '$lib/types/compare';
+	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import type { Scenario } from '$lib/types/userState';
+	import * as RadioGroup from '$lib/components/ui/radio-group/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Root } from '$lib/components/ui/button';
 
 	interface Props {
 		chartTheme: string;
@@ -26,23 +31,52 @@
 		),
 		fullLongTermTotals: getTotalCasesAndCostsPerScenario(results.fullLongTerm.cases, formValues.longTermFormValues)
 	});
+	let scenarios = $derived(
+		getScenarioKeys(totals.presentTotals, totals.baselineLongTermTotals, totals.fullLongTermTotals)
+	);
 
 	let selectedIntervention = $state<ScenarioLabel>('No Intervention');
 	let casesConfig = $derived(getCasesCompareConfig(totals, (intervention) => (selectedIntervention = intervention)));
 
-	let tableData = $derived(buildCompareCasesTableData(totals));
+	let tableData = $derived(buildCompareCasesTableData(totals, scenarios));
 
 	let prevalenceConfig = $derived(getPrevalenceConfigCompare(results, selectedIntervention));
 </script>
 
 <div class="flex flex-3/4 flex-col gap-4">
-	<section aria-label="cases compare graph" class="rounded-lg border p-2">
-		<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
-	</section>
-	<section aria-label="prevalence compare graph" class="rounded-lg border p-2">
-		<div {@attach createHighchart(prevalenceConfig)} class={chartTheme}></div>
-	</section>
-	<section aria-label="cases compare table">
-		<DataTable data={tableData} columns={compareCasesTableColumns} />
-	</section>
+	<Tabs.Root value="graph">
+		<div class="flex gap-2">
+			<Tabs.List class="w-full">
+				<Tabs.Trigger value="graph">Graph</Tabs.Trigger>
+				<Tabs.Trigger value="table">Table</Tabs.Trigger>
+			</Tabs.List>
+		</div>
+		<Tabs.Content value="graph">
+			<section aria-label="cases compare graph" class="rounded-lg border p-2">
+				<div {@attach createHighchart(casesConfig)} class={chartTheme}></div>
+			</section>
+		</Tabs.Content>
+		<Tabs.Content value="table">
+			<DataTable data={tableData} columns={compareCasesTableColumns} />
+		</Tabs.Content>
+	</Tabs.Root>
+	<div class="flex flex-col gap-2">
+		<Label>Select intervention to compare prevalence across timeframes:</Label>
+		<RadioGroup.Root class="flex w-full items-center space-x-1" bind:value={selectedIntervention}>
+			{#each scenarios as scenario}
+				<div>
+					<RadioGroup.Item value={ScenarioToLabel[scenario]} id={scenario} class="peer sr-only" />
+					<Label
+						for={scenario}
+						class="flex cursor-pointer items-center rounded-md border p-2.5 text-xs peer-data-[state=checked]:border-primary hover:bg-accent"
+					>
+						{ScenarioToLabel[scenario]}
+					</Label>
+				</div>
+			{/each}
+		</RadioGroup.Root>
+		<section aria-label="prevalence compare graph" class="rounded-lg border p-2">
+			<div {@attach createHighchart(prevalenceConfig)} class={chartTheme}></div>
+		</section>
+	</div>
 </div>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/InterventionFields.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/InterventionFields.svelte
@@ -59,6 +59,7 @@
 				onValueChange={(value: number) => onSliderChange(value, param.parameterName)}
 				max={param.max}
 				min={param.min}
+				step={param.step}
 				disabled={isLoading}
 				aria-label={`Adjust ${param.label} slider`}
 				value={longTermFormValues[param.parameterName] as number}
@@ -83,7 +84,7 @@
 								id={`${cost.costName}-compare-input`}
 								type="number"
 								min={0}
-								step="any"
+								step={cost.step}
 								disabled={isLoading}
 								value={String(longTermFormValues[cost.costName])}
 								oninput={(e) => (longTermFormValues[cost.costName] = Number(e.currentTarget.value))}

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/InterventionFields.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/InterventionFields.svelte
@@ -35,7 +35,7 @@
 		<Field.Description>Update % slider, then adjust associated cost fields</Field.Description>
 	</div>
 	{#each interventionParameters as param (param.parameterName)}
-		<Field.Field>
+		<Field.Field class="gap-3.5">
 			<Field.Label for={`${param.parameterName}-compare-slider`}>
 				<button
 					type="button"

--- a/client/src/routes/projects/[project]/regions/[region]/compare/utils.ts
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/utils.ts
@@ -1,7 +1,8 @@
 import type { FormValue } from '$lib/components/dynamic-region-form/types';
 import { apiFetch } from '$lib/fetch';
+import type { ScenarioTotals } from '$lib/process-results/processCases';
 import type { ResponseBodySuccess } from '$lib/types/api';
-import type { EmulatorResults } from '$lib/types/userState';
+import type { EmulatorResults, Scenario } from '$lib/types/userState';
 import { regionCompareUrl } from '$lib/url';
 
 export const runCompareEmulator = async (
@@ -42,3 +43,7 @@ const triggerEmulator = async (
 			formValues
 		}
 	});
+
+export const getScenariosFromTotals = (
+	...totalsByTimeFrames: Partial<Record<Scenario, ScenarioTotals>>[]
+): Scenario[] => Array.from(new Set(totalsByTimeFrames.flatMap((summary) => Object.keys(summary) as Scenario[])));

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -489,7 +489,7 @@ describe('cases compare config', () => {
 
 	describe('getCasesCompareConfig integration', () => {
 		it('should return a valid Highcharts Options object', () => {
-			const config = getCasesCompareConfig(compareTotals, vi.fn());
+			const config = getCasesCompareConfig(compareTotals);
 
 			expect(config).toBeDefined();
 			expect(config.chart?.type).toBe('line');
@@ -499,7 +499,7 @@ describe('cases compare config', () => {
 		});
 
 		it('should include both Present and Long term series when newCases has data', () => {
-			const config = getCasesCompareConfig(compareTotals, vi.fn());
+			const config = getCasesCompareConfig(compareTotals);
 
 			expect(config.series).toHaveLength(3);
 			expect((config.series as any)[0].name).toBe('Present');
@@ -510,79 +510,26 @@ describe('cases compare config', () => {
 		it('should include only Present series when newCases is empty', () => {
 			vi.spyOn(processCases, 'collectPostInterventionCases').mockReturnValue({} as any);
 
-			const config = getCasesCompareConfig(
-				{ presentTotals: totals, baselineLongTermTotals: {}, fullLongTermTotals: {} },
-				vi.fn()
-			);
+			const config = getCasesCompareConfig({
+				presentTotals: totals,
+				baselineLongTermTotals: {},
+				fullLongTermTotals: {}
+			});
 
 			expect(config.series).toHaveLength(1);
 			expect((config.series as any)[0].name).toBe('Present');
 		});
 
 		it('should apply breaks to xAxis when data points exist', () => {
-			const config = getCasesCompareConfig(compareTotals, vi.fn());
+			const config = getCasesCompareConfig(compareTotals);
 
 			expect((config.xAxis as any).breaks).toBeDefined();
 		});
 
 		it('should set tooltip formatter to createCompareTooltipHtml', () => {
-			const config = getCasesCompareConfig(compareTotals, vi.fn());
+			const config = getCasesCompareConfig(compareTotals);
 
 			expect(config.tooltip?.formatter).toBe(createCompareTooltipHtml);
-		});
-
-		it('line mouseOut should reset all series point states', () => {
-			const setSelectedIntervention = vi.fn();
-
-			const config = getCasesCompareConfig(compareTotals, setSelectedIntervention);
-			const mouseOutHandler = (config.plotOptions as any).line.events.mouseOut;
-
-			const p1 = { setState: vi.fn() };
-			const p2 = { setState: vi.fn() };
-			const p3 = { setState: vi.fn() };
-
-			mouseOutHandler.call({
-				chart: {
-					series: [{ points: [p1, p2] }, { points: [p3] }]
-				}
-			});
-
-			expect(p1.setState).toHaveBeenCalledWith('');
-			expect(p2.setState).toHaveBeenCalledWith('');
-			expect(p3.setState).toHaveBeenCalledWith('');
-		});
-		it('line click should pass clicked intervention to setSelectedIntervention', () => {
-			const setSelectedIntervention = vi.fn();
-
-			const config = getCasesCompareConfig(compareTotals, setSelectedIntervention);
-			const lineClickHandler = (config.plotOptions as any).line.events.click;
-
-			lineClickHandler.call(
-				{},
-				{
-					point: {
-						options: {
-							custom: { intervention: 'IRS Only' }
-						}
-					}
-				}
-			);
-
-			expect(setSelectedIntervention).toHaveBeenCalledWith('IRS Only');
-		});
-
-		it('chart click should select closest intervention using setSelectedIntervention', () => {
-			const setSelectedIntervention = vi.fn();
-
-			const config = getCasesCompareConfig(compareTotals, setSelectedIntervention);
-			const clickHandler = (config.chart as any).events.click;
-
-			const pointA = { x: 1000, options: { custom: { intervention: 'IRS Only' } } };
-			const pointB = { x: 1500, options: { custom: { intervention: 'Pyrethroid ITN (Only)' } } };
-
-			clickHandler.call({ series: [{ data: [pointA, pointB] }] }, { xAxis: [{ value: 1400 }] });
-
-			expect(setSelectedIntervention).toHaveBeenCalledWith('Pyrethroid ITN (Only)');
 		});
 	});
 });

--- a/client/src/tests/lib/components/SliderWithMarker.svelte.spec.ts
+++ b/client/src/tests/lib/components/SliderWithMarker.svelte.spec.ts
@@ -2,7 +2,7 @@ import SliderWithMarker from '$lib/components/SliderWithMarker.svelte';
 import { render } from 'vitest-browser-svelte';
 
 describe('SliderWithMarker component', () => {
-	it('should render slider with marker and change value', async () => {
+	it('should render slider with marker, value and change value', async () => {
 		const value = $state(10);
 		const screen = render(SliderWithMarker, {
 			type: 'single',

--- a/client/src/tests/lib/tables/compareCasesTable.spec.ts
+++ b/client/src/tests/lib/tables/compareCasesTable.spec.ts
@@ -1,19 +1,13 @@
+import { ScenarioToLabel } from '$lib/charts/baseChart';
 import { renderComponent } from '$lib/components/ui/data-table';
 import {
 	buildCompareCasesTableData,
 	compareCasesTableColumns,
 	getCasesCell,
 	getCasesHeader,
-	getCostsHeader,
-	getScenarioKeys
+	getCostsHeader
 } from '$lib/tables/compareCasesTable';
-
-vi.mock('$lib/charts/baseChart', () => ({
-	ScenarioToLabel: {
-		baseline: 'Baseline',
-		intervention: 'Intervention'
-	}
-}));
+import type { Scenario } from '$lib/types/userState';
 
 vi.mock('$lib/components/data-table/DataTableSortHeader.svelte', () => ({
 	default: 'DataTableSortHeader'
@@ -27,34 +21,28 @@ describe('compareCasesTable', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
-
-	it('getScenarioKeys returns unique scenarios preserving first-seen order', () => {
-		const keys = getScenarioKeys(
-			{ baseline: { totalCost: 1, totalCases: 2 } } as any,
-			{ intervention: { totalCost: 3, totalCases: 4 }, baseline: { totalCost: 5, totalCases: 6 } } as any,
-			{ intervention: { totalCost: 7, totalCases: 8 } } as any
-		);
-
-		expect(keys).toEqual(['baseline', 'intervention']);
-	});
+	const scenarios = ['no_intervention', 'lsm_only'] as Scenario[];
 
 	it('buildCompareCasesTableData merges totals across all timeframes', () => {
-		const data = buildCompareCasesTableData({
-			presentTotals: {
-				baseline: { totalCost: 100, totalCases: 10 }
-			},
-			baselineLongTermTotals: {
-				baseline: { totalCost: 200, totalCases: 20 },
-				intervention: { totalCost: 300, totalCases: 30 }
-			},
-			fullLongTermTotals: {
-				intervention: { totalCost: 400, totalCases: 40 }
-			}
-		} as any);
+		const data = buildCompareCasesTableData(
+			{
+				presentTotals: {
+					no_intervention: { totalCost: 100, totalCases: 10 }
+				},
+				baselineLongTermTotals: {
+					no_intervention: { totalCost: 200, totalCases: 20 },
+					lsm_only: { totalCost: 300, totalCases: 30 }
+				},
+				fullLongTermTotals: {
+					lsm_only: { totalCost: 400, totalCases: 40 }
+				}
+			} as any,
+			scenarios
+		);
 
 		expect(data).toEqual([
 			{
-				intervention: 'Baseline',
+				intervention: ScenarioToLabel['no_intervention'],
 				presentCost: 100,
 				presentCases: 10,
 				longTermBaselineCost: 200,
@@ -63,7 +51,7 @@ describe('compareCasesTable', () => {
 				fullLongTermCases: undefined
 			},
 			{
-				intervention: 'Intervention',
+				intervention: ScenarioToLabel['lsm_only'],
 				presentCost: undefined,
 				presentCases: undefined,
 				longTermBaselineCost: 300,

--- a/client/src/tests/lib/tables/compareCasesTable.spec.ts
+++ b/client/src/tests/lib/tables/compareCasesTable.spec.ts
@@ -9,7 +9,6 @@ import {
 	getCostsHeader
 } from '$lib/tables/compareCasesTable';
 import type { Scenario } from '$lib/types/userState';
-import { createRawSnippet } from 'svelte';
 vi.mock('$lib/components/data-table/DataTableSortHeader.svelte', () => ({
 	default: 'DataTableSortHeader'
 }));

--- a/client/src/tests/lib/tables/compareCasesTable.spec.ts
+++ b/client/src/tests/lib/tables/compareCasesTable.spec.ts
@@ -1,21 +1,31 @@
 import { ScenarioToLabel } from '$lib/charts/baseChart';
-import { renderComponent } from '$lib/components/ui/data-table';
+import { renderComponent, renderSnippet } from '$lib/components/ui/data-table';
 import {
 	buildCompareCasesTableData,
+	casesCellSnippet,
 	compareCasesTableColumns,
 	getCasesCell,
 	getCasesHeader,
 	getCostsHeader
 } from '$lib/tables/compareCasesTable';
 import type { Scenario } from '$lib/types/userState';
-
+import { createRawSnippet } from 'svelte';
 vi.mock('$lib/components/data-table/DataTableSortHeader.svelte', () => ({
 	default: 'DataTableSortHeader'
 }));
 
 vi.mock('$lib/components/ui/data-table', () => ({
-	renderComponent: vi.fn(() => 'rendered-header')
+	renderComponent: vi.fn(() => 'rendered-header'),
+	renderSnippet: vi.fn(() => 'rendered-cell')
 }));
+
+// const hoisted = vi.hoisted(() => ({
+// 	rawSnippetRef: { render: () => '<span />' }
+// }));
+
+// vi.mock('svelte', () => ({
+// 	createRawSnippet: vi.fn(() => hoisted.rawSnippetRef)
+// }));
 
 describe('compareCasesTable', () => {
 	beforeEach(() => {
@@ -62,10 +72,35 @@ describe('compareCasesTable', () => {
 		]);
 	});
 
-	it('getCasesCell formats numeric values and handles undefined', () => {
-		const cell = getCasesCell().cell;
-		expect(cell({ getValue: () => 1200 } as any)).toBe('1,200');
-		expect(cell({ getValue: () => undefined } as any)).toBe('-');
+	describe('getCasesCell', () => {
+		it('getCasesCell handles undefined', () => {
+			const cell = getCasesCell().cell;
+			expect(cell({ getValue: () => undefined } as any)).toBe('-');
+		});
+		it('should handle presentCases with no percentage', () => {
+			const cell = getCasesCell().cell;
+			const result = cell({ getValue: () => 1000, column: { id: 'presentCases' } } as any);
+
+			expect(vi.mocked(renderSnippet)).toHaveBeenCalledWith(casesCellSnippet, {
+				value: 1000,
+				percentageChange: 0
+			});
+			expect(result).toBe('rendered-cell');
+		});
+		it('should handle not presentCases with percentage', () => {
+			const cell = getCasesCell().cell;
+			const result = cell({
+				getValue: () => 1000,
+				column: { id: 'longTermBaselineCases' },
+				row: { getValue: () => 800 }
+			} as any);
+
+			expect(vi.mocked(renderSnippet)).toHaveBeenCalledWith(casesCellSnippet, {
+				value: 1000,
+				percentageChange: 25
+			});
+			expect(result).toBe('rendered-cell');
+		});
 	});
 
 	it('getCasesHeader uses sortable header renderer with Cases label', () => {

--- a/client/src/tests/mocks/mocks.ts
+++ b/client/src/tests/mocks/mocks.ts
@@ -564,13 +564,15 @@ export const MOCK_COMPARE_PARAMETERS: Readonly<CompareParameters> = Object.freez
 			parameterName: 'current_malaria_prevalence',
 			label: 'Prevalence',
 			min: 2,
-			max: 70
+			max: 70,
+			step: 1
 		},
 		{
 			parameterName: 'preference_for_biting_in_bed',
 			label: 'Preference for Biting in Bed',
 			min: 40,
-			max: 90
+			max: 90,
+			step: 1
 		}
 	],
 	interventionParameters: [
@@ -579,10 +581,12 @@ export const MOCK_COMPARE_PARAMETERS: Readonly<CompareParameters> = Object.freez
 			label: 'IRS coverage',
 			min: 0,
 			max: 100,
+			step: 1,
 			linkedCosts: [
 				{
 					costName: 'irs_household_annual_cost_deployment',
-					costLabel: 'IRS annual household cost deployment'
+					costLabel: 'IRS annual household cost deployment',
+					step: 0.1
 				}
 			]
 		},
@@ -591,14 +595,16 @@ export const MOCK_COMPARE_PARAMETERS: Readonly<CompareParameters> = Object.freez
 			label: 'ITN usage',
 			min: 0,
 			max: 100,
-			linkedCosts: [{ costName: 'mass_distribution_cost', costLabel: 'Mass distribution cost' }]
+			step: 1,
+			linkedCosts: [{ costName: 'mass_distribution_cost', costLabel: 'Mass distribution cost', step: 0.1 }]
 		},
 		{
 			parameterName: 'lsm',
 			label: 'LSM coverage',
 			min: 0,
 			max: 90,
-			linkedCosts: [{ costName: 'lsm_cost', costLabel: 'LSM annual cost' }]
+			step: 1,
+			linkedCosts: [{ costName: 'lsm_cost', costLabel: 'LSM annual cost', step: 0.1 }]
 		}
 	]
 });

--- a/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
@@ -2,38 +2,52 @@ import { MOCK_CASES_DATA, MOCK_FORM_VALUES, MOCK_PREVALENCE_DATA } from '$mocks/
 import ComparePlots from '$routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte';
 import { render } from 'vitest-browser-svelte';
 
-describe('Compare CompareResults component', () => {
-	it('should render graphs & table with present and long term results', async () => {
-		const screen = render(ComparePlots, {
-			props: {
-				chartTheme: 'highcharts-dark',
-				results: {
-					present: {
-						cases: MOCK_CASES_DATA,
-						prevalence: MOCK_PREVALENCE_DATA,
-						eirValid: true
-					},
-					fullLongTerm: {
-						cases: MOCK_CASES_DATA,
-						prevalence: MOCK_PREVALENCE_DATA,
-						eirValid: true
-					},
-					baselineLongTerm: {
-						cases: MOCK_CASES_DATA,
-						prevalence: MOCK_PREVALENCE_DATA,
-						eirValid: true
-					}
+vi.mock('$routes/projects/[project]/regions/[region]/compare/utils', () => ({
+	getScenariosFromTotals: vi.fn(() => ['no_intervention', 'irs_only'])
+}));
+
+const renderComponent = (props: any = {}) =>
+	render(ComparePlots, {
+		props: {
+			chartTheme: 'highcharts-dark',
+			results: {
+				present: {
+					cases: MOCK_CASES_DATA,
+					prevalence: MOCK_PREVALENCE_DATA,
+					eirValid: true
 				},
-				formValues: {
-					presentFormValues: MOCK_FORM_VALUES,
-					longTermFormValues: MOCK_FORM_VALUES
+				fullLongTerm: {
+					cases: MOCK_CASES_DATA,
+					prevalence: MOCK_PREVALENCE_DATA,
+					eirValid: true
+				},
+				baselineLongTerm: {
+					cases: MOCK_CASES_DATA,
+					prevalence: MOCK_PREVALENCE_DATA,
+					eirValid: true
 				}
-			}
-		} as any);
+			},
+			formValues: {
+				presentFormValues: MOCK_FORM_VALUES,
+				longTermFormValues: MOCK_FORM_VALUES
+			},
+			isLoading: false,
+			...props
+		}
+	} as any);
+
+describe('Compare CompareResults component', () => {
+	it('should render loading state when isLoading is true', async () => {
+		const screen = renderComponent({ isLoading: true });
+
+		await expect.element(screen.getByText('Loading...')).toBeVisible();
+	});
+
+	it('should render cases and prevalence graphs by default', async () => {
+		const screen = renderComponent();
 
 		await expect.element(screen.getByRole('region', { name: 'prevalence compare graph' })).toBeVisible();
 		await expect.element(screen.getByRole('region', { name: 'cases compare graph' })).toBeVisible();
-		await expect.element(screen.getByRole('table')).toBeVisible();
 
 		const presentLegendLabels = screen.getByRole('button', { name: 'Show Present' }).all();
 		const baselineLongTermLegendLabels = screen.getByRole('button', { name: 'Show Long Term (baseline only)' }).all();
@@ -46,5 +60,34 @@ describe('Compare CompareResults component', () => {
 			await expect.element(baselineLongTermLegendLabels[i]).toBeVisible();
 			await expect.element(fullLongTermLegendLabels[i]).toBeVisible();
 		}
+	});
+
+	it("should show table view when 'Table' tab is selected", async () => {
+		const screen = renderComponent();
+
+		await screen.getByRole('tab', { name: 'Table' }).click();
+
+		await expect.element(screen.getByRole('columnheader', { name: 'Intervention' })).toBeVisible();
+		await expect.element(screen.getByRole('columnheader', { name: 'Present' })).toBeVisible();
+		await expect.element(screen.getByRole('columnheader', { name: 'Long term (baseline only)' })).toBeVisible();
+		await expect
+			.element(screen.getByRole('columnheader', { name: 'Long term (baseline + control strategy)' }))
+			.toBeVisible();
+	});
+
+	it('should show prevalence graph for specific intervention when selected in radio group', async () => {
+		const screen = renderComponent();
+
+		await expect
+			.element(
+				screen.getByRole('region', { name: 'prevalence compare graph' }).getByText('No Intervention', { exact: true })
+			)
+			.toBeVisible();
+
+		await screen.getByRole('radio', { name: 'IRS Only' }).click();
+
+		await expect
+			.element(screen.getByRole('region', { name: 'prevalence compare graph' }).getByText('IRS Only', { exact: true }))
+			.toBeVisible();
 	});
 });

--- a/client/src/tests/routes/projects/[project]/regions/[region]/compare/utils.spec.ts
+++ b/client/src/tests/routes/projects/[project]/regions/[region]/compare/utils.spec.ts
@@ -1,4 +1,4 @@
-import { runCompareEmulator } from '$routes/projects/[project]/regions/[region]/compare/utils';
+import { getScenariosFromTotals, runCompareEmulator } from '$routes/projects/[project]/regions/[region]/compare/utils';
 import { regionCompareUrl } from '$lib/url';
 import { apiFetch } from '$lib/fetch';
 
@@ -76,6 +76,16 @@ describe('utils', () => {
 					mockSelectedBaselineParameter
 				)
 			).rejects.toThrow(new Error('API fetch failed'));
+		});
+
+		it('getScenariosFromTotals returns unique scenarios preserving first-seen order', () => {
+			const keys = getScenariosFromTotals(
+				{ baseline: { totalCost: 1, totalCases: 2 } } as any,
+				{ intervention: { totalCost: 3, totalCases: 4 }, baseline: { totalCost: 5, totalCases: 6 } } as any,
+				{ intervention: { totalCost: 7, totalCases: 8 } } as any
+			);
+
+			expect(keys).toEqual(['baseline', 'intervention']);
 		});
 	});
 });

--- a/server-python/app/models.py
+++ b/server-python/app/models.py
@@ -113,11 +113,13 @@ class CompareParameter(BaseModel):
     label: str
     min: float
     max: float
+    step: float
 
 
 class InterventionCompareCost(BaseModel):
     cost_name: str = Field(serialization_alias="costName")
     cost_label: str = Field(serialization_alias="costLabel")
+    step: float
 
 
 class InterventionCompareParameter(CompareParameter):

--- a/server-python/app/resources/dynamicFormOptions.json
+++ b/server-python/app/resources/dynamicFormOptions.json
@@ -335,7 +335,7 @@
               "type": "number",
               "required": true,
               "default": 1.85,
-              "step": 0.01
+              "step": 0.1
             },
             {
               "id": "py_pbo_cost",
@@ -343,7 +343,7 @@
               "type": "number",
               "required": true,
               "default": 2.14,
-              "step": 0.01
+              "step": 0.1
             },
             {
               "id": "py_pyrrole_cost",
@@ -351,7 +351,7 @@
               "type": "number",
               "required": true,
               "default": 2.56,
-              "step": 0.01
+              "step": 0.1
             },
             {
               "id": "py_ppf_cost",
@@ -359,7 +359,7 @@
               "type": "number",
               "required": true,
               "default": 2.86,
-              "step": 0.01
+              "step": 0.1
             },
             {
               "id": "mass_distribution_cost",
@@ -368,7 +368,7 @@
               "type": "number",
               "required": true,
               "default": 2.75,
-              "step": 0.01
+              "step": 0.1
             },
             {
               "id": "continuous_itn_distribution_cost",
@@ -377,7 +377,7 @@
               "type": "number",
               "required": true,
               "default": 2.75,
-              "step": 0.01
+              "step": 0.1
             },
             {
               "id": "irs_household_annual_cost_product",

--- a/server-python/app/services/resources.py
+++ b/server-python/app/services/resources.py
@@ -32,7 +32,7 @@ def get_dynamic_form_options() -> dict:
 def get_compare_parameters() -> CompareParametersResponse:
     form_options = get_dynamic_form_options()
     baseline_param_names = [
-        ("current_malaria_prevalence", "Baseline prevalence"),
+        ("current_malaria_prevalence", "Prevalence"),
     ]
     intervention_param_names = [
         (
@@ -65,6 +65,7 @@ def create_intervention_compare_parameter(
         InterventionCompareCost(
             cost_name=cost_field["id"],
             cost_label=cost_field.get("label", cost_field["id"]),
+            step=cost_field.get("step", 1.0),
         )
         for cost_field in cost_fields
     ]
@@ -84,6 +85,7 @@ def create_compare_parameter(
         label=label,
         min=field.get("min", 0.0),
         max=field.get("max", 100.0),
+        step=field.get("step", 1.0),
     )
 
 

--- a/server-python/tests/services/test_resources.py
+++ b/server-python/tests/services/test_resources.py
@@ -131,6 +131,7 @@ class TestCreateCompareParameter:
             "label": "Prevalence",
             "min": 2,
             "max": 70,
+            "step": 1.0,
         }
 
     def test_create_compare_parameter_no_min_max(self):
@@ -143,6 +144,7 @@ class TestCreateCompareParameter:
             "label": "No Min Max",
             "min": 0.0,
             "max": 100.0,
+            "step": 1.0,
         }
 
     def test_create_intervention_compare_parameter(self):
@@ -155,9 +157,10 @@ class TestCreateCompareParameter:
             "label": "ITN Usage",
             "min": 0.0,
             "max": 100.0,
+            "step": 1.0,
             "linked_costs": [
-                {"cost_name": "itn_cost1", "cost_label": "ITN Cost 1"},
-                {"cost_name": "itn_cost2", "cost_label": "ITN Cost 2"},
+                {"cost_name": "itn_cost1", "cost_label": "ITN Cost 1", "step": 1.0},
+                {"cost_name": "itn_cost2", "cost_label": "ITN Cost 2", "step": 1.0},
             ],
         }
 
@@ -170,7 +173,11 @@ class TestGetCompareParameters:
         options = {"field": "test"}
         baseline_parameters = [
             CompareParameter(
-                parameter_name="preference_for_biting_in_bed", label="Preference for Biting in Bed", min=0, max=100
+                parameter_name="preference_for_biting_in_bed",
+                label="Preference for Biting in Bed",
+                min=0,
+                max=100,
+                step=1.0,
             ),
         ]
         intervention_parameters = [
@@ -179,9 +186,12 @@ class TestGetCompareParameters:
                 label="IRS coverage",
                 min=0,
                 max=100,
+                step=1.0,
                 linked_costs=[
                     InterventionCompareCost(
-                        cost_name="irs_household_annual_cost_product", cost_label="IRSHousehold Annual Cost Product"
+                        cost_name="irs_household_annual_cost_product",
+                        cost_label="IRSHousehold Annual Cost Product",
+                        step=1.0,
                     )
                 ],
             ),
@@ -190,8 +200,11 @@ class TestGetCompareParameters:
                 label="ITN usage",
                 min=0,
                 max=100,
+                step=1.0,
                 linked_costs=[
-                    InterventionCompareCost(cost_name="mass_distribution_cost", cost_label="Mass Distribution Cost"),
+                    InterventionCompareCost(
+                        cost_name="mass_distribution_cost", cost_label="Mass Distribution Cost", step=1.0
+                    ),
                 ],
             ),
             InterventionCompareParameter(
@@ -199,7 +212,8 @@ class TestGetCompareParameters:
                 label="LSM coverage",
                 min=0,
                 max=100,
-                linked_costs=[InterventionCompareCost(cost_name="lsm_cost", cost_label="LSM Cost")],
+                step=1.0,
+                linked_costs=[InterventionCompareCost(cost_name="lsm_cost", cost_label="LSM Cost", step=1.0)],
             ),
         ]
         mock_options.return_value = options
@@ -210,7 +224,7 @@ class TestGetCompareParameters:
 
         mock_options.assert_called_once()
         expected_compare_calls = [
-            (("current_malaria_prevalence", "Baseline prevalence"), options),
+            (("current_malaria_prevalence", "Prevalence"), options),
         ]
         expected_intervention_compare_calls = [
             (

--- a/server-python/tests/test_models.py
+++ b/server-python/tests/test_models.py
@@ -238,18 +238,19 @@ class TestEmulatorResponse:
 
 class TestCompareParameter:
     def test_compare_parameter_creation(self):
-        param = CompareParameter(parameter_name="test_param", label="Test Parameter", min=0.0, max=100.0)
+        param = CompareParameter(parameter_name="test_param", label="Test Parameter", min=0.0, max=100.0, step=1.0)
         assert param.parameter_name == "test_param"
         assert param.label == "Test Parameter"
         assert param.min == 0.0
         assert param.max == 100.0
+        assert param.step == 1.0
 
 
 class TestCompareParametersResponse:
     def test_compare_parameters_response_creation(self):
         baseline_params = [
-            CompareParameter(parameter_name="param1", label="Parameter 1", min=0.0, max=50.0),
-            CompareParameter(parameter_name="param2", label="Parameter 2", min=10.0, max=60.0),
+            CompareParameter(parameter_name="param1", label="Parameter 1", min=0.0, max=50.0, step=1.0),
+            CompareParameter(parameter_name="param2", label="Parameter 2", min=10.0, max=60.0, step=1.0),
         ]
         intervention_params = [
             InterventionCompareParameter(
@@ -257,9 +258,10 @@ class TestCompareParametersResponse:
                 label="Parameter 3",
                 min=20.0,
                 max=70.0,
+                step=1.0,
                 linked_costs=[
-                    InterventionCompareCost(cost_name="cost3", cost_label="Cost 3"),
-                    InterventionCompareCost(cost_name="cost4", cost_label="Cost 4"),
+                    InterventionCompareCost(cost_name="cost3", cost_label="Cost 3", step=1.0),
+                    InterventionCompareCost(cost_name="cost4", cost_label="Cost 4", step=1.0),
                 ],
             ),
         ]
@@ -271,7 +273,9 @@ class TestCompareParametersResponse:
         assert len(response.intervention_parameters) == 1
         assert response.baseline_parameters[0].parameter_name == "param1"
         assert response.intervention_parameters[0].label == "Parameter 3"
-        assert {(cost.cost_name, cost.cost_label) for cost in response.intervention_parameters[0].linked_costs} == {
-            ("cost3", "Cost 3"),
-            ("cost4", "Cost 4"),
+        assert {
+            (cost.cost_name, cost.cost_label, cost.step) for cost in response.intervention_parameters[0].linked_costs
+        } == {
+            ("cost3", "Cost 3", 1.0),
+            ("cost4", "Cost 4", 1.0),
         }


### PR DESCRIPTION
The following PR contains last batch of feedback from tom/emma. The following is done in this PR:
- Move table from bottom into its own tab with the cases plot
- remove ability to click on cases graph to trigger prevalence plot. We just now have a selection of inteventions can select to visualise prevalence for that intervention
- pass in step size for slider + numerical fields.
- naming + form step updates

<img width="1367" height="718" alt="image" src="https://github.com/user-attachments/assets/0f634310-efc1-41b2-8fdf-67f397943547" />