### PR TITLE
Compare feedback 3

### DIFF
--- a/client/e2e/compare.test.ts
+++ b/client/e2e/compare.test.ts
@@ -55,16 +55,18 @@ test.describe('E2E Compare Page', () => {
 		// prevalence plot
 		const prevalencePlot = page.getByRole('region', { name: 'prevalence compare graph' });
 		await expect(prevalencePlot).toBeVisible();
-		await expect(prevalencePlot.getByRole('button', { name: 'Show Long term (baseline only)' })).toBeVisible();
 		await expect(
-			prevalencePlot.getByRole('button', { name: 'Show Long term (baseline + control strategy)' })
+			prevalencePlot.getByRole('button', { name: 'Show Long-term (current control strategy)' })
+		).toBeVisible();
+		await expect(
+			prevalencePlot.getByRole('button', { name: 'Show Long-term (current control strategy)' })
 		).toBeVisible();
 		await expect(prevalencePlot.getByRole('button', { name: 'Show Present' })).toBeVisible();
 		// cases plot
 		const casesPlot = page.getByRole('region', { name: 'cases compare graph' });
 		await expect(casesPlot).toBeVisible();
-		await expect(casesPlot.getByRole('button', { name: 'Show Long term (baseline only)' })).toBeVisible();
-		await expect(casesPlot.getByRole('button', { name: 'Show Long term (baseline + control strategy)' })).toBeVisible();
+		await expect(casesPlot.getByRole('button', { name: 'Show Long-term (current control strategy)' })).toBeVisible();
+		await expect(casesPlot.getByRole('button', { name: 'Show Long-term (adjusted control strategy)' })).toBeVisible();
 		await expect(casesPlot.getByRole('button', { name: 'Show Present' })).toBeVisible();
 	});
 
@@ -75,9 +77,9 @@ test.describe('E2E Compare Page', () => {
 		await page.getByRole('tab', { name: 'Table' }).click();
 		await expect(page.getByRole('table')).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: 'Intervention' })).toBeVisible();
-		await expect(page.getByRole('columnheader', { name: 'Long term (baseline only)' })).toBeVisible();
-		await expect(page.getByRole('columnheader', { name: 'Present' })).toBeVisible();
-		await expect(page.getByRole('columnheader', { name: 'Long term (baseline + control strategy)' })).toBeVisible();
+		await expect(page.getByRole('columnheader', { name: 'Long-term (current control strategy)' })).toBeVisible();
+		await expect(page.getByRole('columnheader', { name: 'Present (current control strategy)' })).toBeVisible();
+		await expect(page.getByRole('columnheader', { name: 'Long-term (adjusted control strategy)' })).toBeVisible();
 
 		const allCostColumns = await page.getByRole('columnheader', { name: /cost/i }).all();
 		expect(allCostColumns.length).toBe(3);

--- a/client/e2e/compare.test.ts
+++ b/client/e2e/compare.test.ts
@@ -56,17 +56,17 @@ test.describe('E2E Compare Page', () => {
 		const prevalencePlot = page.getByRole('region', { name: 'prevalence compare graph' });
 		await expect(prevalencePlot).toBeVisible();
 		await expect(
-			prevalencePlot.getByRole('button', { name: 'Show Long-term (current control strategy)' })
+			prevalencePlot.getByRole('button', { name: 'Show Long-term (current control strategies)' })
 		).toBeVisible();
 		await expect(
-			prevalencePlot.getByRole('button', { name: 'Show Long-term (current control strategy)' })
+			prevalencePlot.getByRole('button', { name: 'Show Long-term (current control strategies)' })
 		).toBeVisible();
 		await expect(prevalencePlot.getByRole('button', { name: 'Show Present' })).toBeVisible();
 		// cases plot
 		const casesPlot = page.getByRole('region', { name: 'cases compare graph' });
 		await expect(casesPlot).toBeVisible();
-		await expect(casesPlot.getByRole('button', { name: 'Show Long-term (current control strategy)' })).toBeVisible();
-		await expect(casesPlot.getByRole('button', { name: 'Show Long-term (adjusted control strategy)' })).toBeVisible();
+		await expect(casesPlot.getByRole('button', { name: 'Show Long-term (current control strategies)' })).toBeVisible();
+		await expect(casesPlot.getByRole('button', { name: 'Show Long-term (adjusted control strategies)' })).toBeVisible();
 		await expect(casesPlot.getByRole('button', { name: 'Show Present' })).toBeVisible();
 	});
 
@@ -77,9 +77,9 @@ test.describe('E2E Compare Page', () => {
 		await page.getByRole('tab', { name: 'Table' }).click();
 		await expect(page.getByRole('table')).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: 'Intervention' })).toBeVisible();
-		await expect(page.getByRole('columnheader', { name: 'Long-term (current control strategy)' })).toBeVisible();
-		await expect(page.getByRole('columnheader', { name: 'Present (current control strategy)' })).toBeVisible();
-		await expect(page.getByRole('columnheader', { name: 'Long-term (adjusted control strategy)' })).toBeVisible();
+		await expect(page.getByRole('columnheader', { name: 'Long-term (current control strategies)' })).toBeVisible();
+		await expect(page.getByRole('columnheader', { name: 'Present (current control strategies)' })).toBeVisible();
+		await expect(page.getByRole('columnheader', { name: 'Long-term (adjusted control strategies)' })).toBeVisible();
 
 		const allCostColumns = await page.getByRole('columnheader', { name: /cost/i }).all();
 		expect(allCostColumns.length).toBe(3);

--- a/client/e2e/region.test.ts
+++ b/client/e2e/region.test.ts
@@ -17,7 +17,7 @@ test.describe('Region page', () => {
 		await page.getByRole('button', { name: 'Run baseline' }).click();
 
 		await expect(
-			page.getByLabel('Interactive chart', { exact: true }).getByText('Projected prevalence in under')
+			page.getByLabel('Interactive chart', { exact: true }).getByText('Prevalence (0-5 years)')
 		).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Intervention Options' })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Cost Options' })).toBeVisible();

--- a/client/e2e/strategise.test.ts
+++ b/client/e2e/strategise.test.ts
@@ -42,7 +42,9 @@ test.describe('Strategise page', () => {
 
 		// chart visibility
 		await expect(
-			page.getByLabel('Interactive chart', { exact: true }).getByText('Total Cases Averted vs Total')
+			page
+				.getByLabel('Interactive chart', { exact: true })
+				.getByText('Total Clinical Cases Averted and Cost of Strategy')
 		).toBeVisible();
 
 		// individual region cards
@@ -62,7 +64,9 @@ test.describe('Strategise page', () => {
 
 		// Verify strategise data is present
 		await expect(
-			page.getByLabel('Interactive chart', { exact: true }).getByText('Total Cases Averted vs Total')
+			page
+				.getByLabel('Interactive chart', { exact: true })
+				.getByText('Total Clinical Cases Averted and Cost of Strategy')
 		).toBeVisible();
 
 		// Re-run interventions for uk region
@@ -73,7 +77,9 @@ test.describe('Strategise page', () => {
 		await page.getByRole('link', { name: 'Sub-national tailoring' }).click();
 
 		await expect(
-			page.getByLabel('Interactive chart', { exact: true }).getByText('Total Cases Averted vs Total')
+			page
+				.getByLabel('Interactive chart', { exact: true })
+				.getByText('Total Clinical Cases Averted and Cost of Strategy')
 		).toBeHidden();
 	});
 });

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -205,7 +205,7 @@ export const getCasesCompareConfig = ({
 			height: 450
 		},
 		title: {
-			text: 'Present vs Long term - Total Cases vs Total Cost'
+			text: 'Total Clinical Cases and Cost of Strategy'
 		},
 		subtitle: {
 			text: 'Step lines show the most cost-effective intervention at each cost level',

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -116,9 +116,9 @@ export const createCasesCompareDataPoints = (
 export const createCasesCompareSeries = (
 	totalCasesAndCosts: Partial<Record<Scenario, ScenarioTotals>>,
 	name:
-		| 'Present (current control strategy)'
-		| 'Long-term (adjusted control strategy)'
-		| 'Long-term (current control strategy)'
+		| 'Present (current control strategies)'
+		| 'Long-term (adjusted control strategies)'
+		| 'Long-term (current control strategies)'
 ): SeriesLineOptions => ({
 	name,
 	type: 'line',
@@ -190,12 +190,12 @@ export const getCasesCompareConfig = ({
 	baselineLongTermTotals,
 	fullLongTermTotals
 }: CompareTotals): Options => {
-	const presentSeries = createCasesCompareSeries(presentTotals, 'Present (current control strategy)');
+	const presentSeries = createCasesCompareSeries(presentTotals, 'Present (current control strategies)');
 	const baselineLongTermSeries = createCasesCompareSeries(
 		baselineLongTermTotals,
-		'Long-term (current control strategy)'
+		'Long-term (current control strategies)'
 	);
-	const fullLongTermSeries = createCasesCompareSeries(fullLongTermTotals, 'Long-term (adjusted control strategy)');
+	const fullLongTermSeries = createCasesCompareSeries(fullLongTermTotals, 'Long-term (adjusted control strategies)');
 	const presentData = presentSeries.data as PointOptionsObject[];
 	const fullLongTermData = fullLongTermSeries.data as PointOptionsObject[];
 

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -115,7 +115,10 @@ export const createCasesCompareDataPoints = (
 
 export const createCasesCompareSeries = (
 	totalCasesAndCosts: Partial<Record<Scenario, ScenarioTotals>>,
-	name: 'Present' | 'Long term (baseline + control strategy)' | 'Long term (baseline only)'
+	name:
+		| 'Present (current control strategy)'
+		| 'Long-term (adjusted control strategy)'
+		| 'Long-term (current control strategy)'
 ): SeriesLineOptions => ({
 	name,
 	type: 'line',
@@ -187,9 +190,12 @@ export const getCasesCompareConfig = ({
 	baselineLongTermTotals,
 	fullLongTermTotals
 }: CompareTotals): Options => {
-	const presentSeries = createCasesCompareSeries(presentTotals, 'Present');
-	const baselineLongTermSeries = createCasesCompareSeries(baselineLongTermTotals, 'Long term (baseline only)');
-	const fullLongTermSeries = createCasesCompareSeries(fullLongTermTotals, 'Long term (baseline + control strategy)');
+	const presentSeries = createCasesCompareSeries(presentTotals, 'Present (current control strategy)');
+	const baselineLongTermSeries = createCasesCompareSeries(
+		baselineLongTermTotals,
+		'Long-term (current control strategy)'
+	);
+	const fullLongTermSeries = createCasesCompareSeries(fullLongTermTotals, 'Long-term (adjusted control strategy)');
 	const presentData = presentSeries.data as PointOptionsObject[];
 	const fullLongTermData = fullLongTermSeries.data as PointOptionsObject[];
 
@@ -208,7 +214,7 @@ export const getCasesCompareConfig = ({
 			}
 		},
 		caption: {
-			text: 'Suboptimal interventions are not plotted; view the table to see them.',
+			text: 'Only the most cost-effective interventions are plotted, see Table tab for all options',
 			align: 'left',
 			verticalAlign: 'bottom',
 			style: {
@@ -216,13 +222,13 @@ export const getCasesCompareConfig = ({
 			}
 		},
 		xAxis: {
-			title: { text: 'Total Cost ($USD)' },
+			title: { text: 'Total cost ($USD)' },
 			labels: { format: '${value:,.0f}' },
 			min: 0,
 			breaks: createBreakToMinimizeEmptySpace(presentData, fullLongTermData)
 		},
 		yAxis: {
-			title: { text: 'Total Cases' },
+			title: { text: 'Total cases' },
 			labels: { format: '{value:,.0f}' }
 		},
 		tooltip: {

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -208,7 +208,7 @@ export const getCasesCompareConfig = ({
 			text: 'Present vs Long term - Total Cases vs Total Cost'
 		},
 		subtitle: {
-			text: 'Step lines indicate changes in intervention strategy as budget increases.',
+			text: 'Step lines show the most cost-effective intervention at each cost level',
 			style: {
 				color: 'var(--muted-foreground)'
 			}

--- a/client/src/lib/charts/prevalenceConfig.ts
+++ b/client/src/lib/charts/prevalenceConfig.ts
@@ -93,7 +93,7 @@ export const getPrevalenceConfig = (prevalence: PrevalenceData[]): Highcharts.Op
 		height: 450
 	},
 	title: {
-		text: 'Projected prevalence in under 5 year olds'
+		text: 'Prevalence (0-5 years)'
 	},
 
 	series: createPrevalenceSeries(prevalence)
@@ -118,9 +118,9 @@ export const getPrevalenceConfigCompare = (
 	selectedIntervention: ScenarioLabel
 ): Highcharts.Options => {
 	const series: Highcharts.SeriesSplineOptions[] = [
-		{ data: present.prevalence, name: 'Present' },
-		{ data: baselineLongTerm.prevalence, name: 'Long term (baseline only)' },
-		{ data: fullLongTerm.prevalence, name: 'Long term (baseline + control strategy)' }
+		{ data: present.prevalence, name: 'Present (current control strategy)' },
+		{ data: baselineLongTerm.prevalence, name: 'Long-term (current control strategy)' },
+		{ data: fullLongTerm.prevalence, name: 'Long-term (adjusted control strategy)' }
 	].flatMap(({ data, name }) => createComparisonSeries(data, selectedIntervention, name));
 
 	return {
@@ -130,7 +130,7 @@ export const getPrevalenceConfigCompare = (
 			height: 500
 		},
 		title: {
-			text: `Prevalence in under 5 year olds - <em>${selectedIntervention}</em>`
+			text: `Prevalence (0-5 years) - <em>${selectedIntervention}</em>`
 		},
 
 		tooltip: {

--- a/client/src/lib/charts/prevalenceConfig.ts
+++ b/client/src/lib/charts/prevalenceConfig.ts
@@ -118,9 +118,9 @@ export const getPrevalenceConfigCompare = (
 	selectedIntervention: ScenarioLabel
 ): Highcharts.Options => {
 	const series: Highcharts.SeriesSplineOptions[] = [
-		{ data: present.prevalence, name: 'Present (current control strategy)' },
-		{ data: baselineLongTerm.prevalence, name: 'Long-term (current control strategy)' },
-		{ data: fullLongTerm.prevalence, name: 'Long-term (adjusted control strategy)' }
+		{ data: present.prevalence, name: 'Present (current control strategies)' },
+		{ data: baselineLongTerm.prevalence, name: 'Long-term (current control strategies)' },
+		{ data: fullLongTerm.prevalence, name: 'Long-term (adjusted control strategies)' }
 	].flatMap(({ data, name }) => createComparisonSeries(data, selectedIntervention, name));
 
 	return {

--- a/client/src/lib/charts/strategyConfig.ts
+++ b/client/src/lib/charts/strategyConfig.ts
@@ -66,7 +66,7 @@ export const getStrategyConfig = (
 		}
 	},
 	title: {
-		text: 'Total Cases Averted vs Total Budget'
+		text: 'Total Clinical Cases Averted and Cost of Strategy'
 	},
 	subtitle: {
 		text:
@@ -77,7 +77,7 @@ export const getStrategyConfig = (
 	},
 	xAxis: {
 		title: {
-			text: 'Total budget ($USD)'
+			text: 'Total cost ($USD)'
 		},
 
 		labels: {

--- a/client/src/lib/components/FieldWithChange.svelte
+++ b/client/src/lib/components/FieldWithChange.svelte
@@ -33,7 +33,6 @@
 <div class="flex flex-row items-center gap-2">
 	{@render children()}
 	<span class="min-w-10 text-right text-sm font-medium tabular-nums">
-		{sign}
-		{prefixUnit}{convertToLocaleString(Math.abs(change), fractionalDigits)}{postfixUnit}</span
+		{sign} {prefixUnit}{convertToLocaleString(Math.abs(change), fractionalDigits)}{postfixUnit}</span
 	>
 </div>

--- a/client/src/lib/components/FieldWithChange.svelte
+++ b/client/src/lib/components/FieldWithChange.svelte
@@ -10,6 +10,7 @@
 		postfixUnit?: string;
 		fractionalDigits?: number;
 		displayChangeAsPercentage?: boolean;
+		invertSign?: boolean;
 	}
 	let {
 		children,
@@ -18,15 +19,21 @@
 		prefixUnit,
 		postfixUnit,
 		fractionalDigits = 1,
-		displayChangeAsPercentage = false
+		displayChangeAsPercentage = false,
+		invertSign = false
 	}: Props = $props();
 	const change = $derived(displayChangeAsPercentage ? ((value - baseline) / baseline) * 100 : value - baseline);
+	const sign = $derived.by(() => {
+		if (change === 0) return '';
+		if (invertSign) return change > 0 ? '-' : '+';
+		return change > 0 ? '+' : '-';
+	});
 </script>
 
 <div class="flex flex-row items-center gap-2">
 	{@render children()}
 	<span class="min-w-10 text-right text-sm font-medium tabular-nums">
-		{#if change >= 0}+{:else}-{/if}
+		{sign}
 		{prefixUnit}{convertToLocaleString(Math.abs(change), fractionalDigits)}{postfixUnit}</span
 	>
 </div>

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -96,7 +96,7 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	},
 	{
 		accessorKey: 'present',
-		header: 'Present',
+		header: 'Present (current control strategy)',
 		columns: [
 			{
 				accessorKey: 'presentCases',
@@ -112,7 +112,7 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	},
 	{
 		accessorKey: 'longTermBaseline',
-		header: 'Long term (baseline only)',
+		header: 'Long-term (current control strategy)',
 		columns: [
 			{
 				accessorKey: 'longTermBaselineCases',
@@ -128,7 +128,7 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	},
 	{
 		accessorKey: 'fullLongTerm',
-		header: 'Long term (baseline + control strategy)',
+		header: 'Long-term (adjusted control strategy)',
 		columns: [
 			{
 				accessorKey: 'fullLongTermCases',

--- a/client/src/lib/tables/compareCasesTable.ts
+++ b/client/src/lib/tables/compareCasesTable.ts
@@ -96,7 +96,7 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	},
 	{
 		accessorKey: 'present',
-		header: 'Present (current control strategy)',
+		header: 'Present (current control strategies)',
 		columns: [
 			{
 				accessorKey: 'presentCases',
@@ -112,7 +112,7 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	},
 	{
 		accessorKey: 'longTermBaseline',
-		header: 'Long-term (current control strategy)',
+		header: 'Long-term (current control strategies)',
 		columns: [
 			{
 				accessorKey: 'longTermBaselineCases',
@@ -128,7 +128,7 @@ export const compareCasesTableColumns: ColumnDef<ComparisonTimeFramesData>[] = [
 	},
 	{
 		accessorKey: 'fullLongTerm',
-		header: 'Long-term (adjusted control strategy)',
+		header: 'Long-term (adjusted control strategies)',
 		columns: [
 			{
 				accessorKey: 'fullLongTermCases',

--- a/client/src/lib/types/compare.ts
+++ b/client/src/lib/types/compare.ts
@@ -13,6 +13,7 @@ export interface InterventionCompareCost {
 	costName: string;
 	costLabel: string;
 	step: number;
+	costDecreasesWithIncrease: boolean;
 }
 export interface InterventionCompareParameter extends CompareParameter {
 	linkedCosts: InterventionCompareCost[];

--- a/client/src/routes/projects/[project]/regions/[region]/compare/+page.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/+page.svelte
@@ -13,8 +13,8 @@
 	<div class="mb-4">
 		<h1 class="text-xl font-bold">Long term Scenario planning</h1>
 		<p class="mb-1 text-muted-foreground">
-			Compare the impact of present interventions versus long-term scenarios. Adjust parameters and modify intervention
-			coverage percentages to see how cases and prevalence change across different budget levels.
+			Compare the impact of control strategies now and in the future following a change to the local epidemiology.
+			Explore how this impacts disease burden and the cost of maintaining control.
 		</p>
 	</div>
 	{#if data.region.hasRunBaseline && data.region.results}

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/Compare.svelte
@@ -85,8 +85,8 @@
 					{/each}
 				</RadioGroup.Root>
 			</Field.Field>
-			<Field.Field class="gap-3.5">
-				<Field.Label for="baseline-parameter-slider" class="sr-only" />
+			<Field.Field class="gap-4">
+				<Field.Label for="baseline-parameter-slider">Change from baseline (%)</Field.Label>
 				<SliderWithMarker
 					id="baseline-parameter-slider"
 					type="single"

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -69,7 +69,7 @@
 		</Tabs.Root>
 		<!-- Prevalence -->
 		<div class="flex flex-col gap-2">
-			<Label>Select intervention to compare prevalence across timeframes:</Label>
+			<Label>Select intervention to compare malaria prevalence for present and long-term scenarios</Label>
 			<RadioGroup.Root class="flex flex-wrap items-center" bind:value={selectedIntervention}>
 				{#each scenarios as scenario (scenario)}
 					<div>

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/InterventionFields.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/InterventionFields.svelte
@@ -35,7 +35,7 @@
 		<Field.Description>Update % slider, then adjust associated cost fields</Field.Description>
 	</div>
 	{#each interventionParameters as param (param.parameterName)}
-		<Field.Field class="gap-3.5">
+		<Field.Field class="gap-4">
 			<Field.Label for={`${param.parameterName}-compare-slider`}>
 				<button
 					type="button"
@@ -79,6 +79,7 @@
 							postfixUnit="%"
 							fractionalDigits={0}
 							displayChangeAsPercentage
+							invertSign={cost.costDecreasesWithIncrease}
 						>
 							<Input
 								id={`${cost.costName}-compare-input`}

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -292,7 +292,7 @@ describe('cases compare config', () => {
 
 	describe('createCasesCompareSeries', () => {
 		it('should create a series with correct name and data points', () => {
-			const series = createCasesCompareSeries(totals, 'Present');
+			const series = createCasesCompareSeries(totals, 'Present (current control strategy)');
 
 			expect(series.name).toBe('Present');
 			expect(series.type).toBe('line');

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -292,9 +292,9 @@ describe('cases compare config', () => {
 
 	describe('createCasesCompareSeries', () => {
 		it('should create a series with correct name and data points', () => {
-			const series = createCasesCompareSeries(totals, 'Present (current control strategy)');
+			const series = createCasesCompareSeries(totals, 'Present (current control strategies)');
 
-			expect(series.name).toBe('Present (current control strategy)');
+			expect(series.name).toBe('Present (current control strategies)');
 			expect(series.type).toBe('line');
 			expect(series.step).toBe('left');
 
@@ -502,9 +502,9 @@ describe('cases compare config', () => {
 			const config = getCasesCompareConfig(compareTotals);
 
 			expect(config.series).toHaveLength(3);
-			expect((config.series as any)[0].name).toBe('Present (current control strategy)');
-			expect((config.series as any)[1].name).toBe('Long-term (current control strategy)');
-			expect((config.series as any)[2].name).toBe('Long-term (adjusted control strategy)');
+			expect((config.series as any)[0].name).toBe('Present (current control strategies)');
+			expect((config.series as any)[1].name).toBe('Long-term (current control strategies)');
+			expect((config.series as any)[2].name).toBe('Long-term (adjusted control strategies)');
 		});
 
 		it('should include only Present series when newCases is empty', () => {
@@ -517,7 +517,7 @@ describe('cases compare config', () => {
 			});
 
 			expect(config.series).toHaveLength(1);
-			expect((config.series as any)[0].name).toBe('Present (current control strategy)');
+			expect((config.series as any)[0].name).toBe('Present (current control strategies)');
 		});
 
 		it('should apply breaks to xAxis when data points exist', () => {

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -294,7 +294,7 @@ describe('cases compare config', () => {
 		it('should create a series with correct name and data points', () => {
 			const series = createCasesCompareSeries(totals, 'Present (current control strategy)');
 
-			expect(series.name).toBe('Present');
+			expect(series.name).toBe('Present (current control strategy)');
 			expect(series.type).toBe('line');
 			expect(series.step).toBe('left');
 

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -494,17 +494,17 @@ describe('cases compare config', () => {
 			expect(config).toBeDefined();
 			expect(config.chart?.type).toBe('line');
 			expect(config.chart?.height).toBe(450);
-			expect(config.title?.text).toBe('Present vs Long term - Total Cases vs Total Cost');
-			expect(config.subtitle?.text).toBe('Step lines indicate changes in intervention strategy as budget increases.');
+			expect(config.title?.text).toBe('Total Clinical Cases and Cost of Strategy');
+			expect(config.subtitle?.text).toBe('Step lines show the most cost-effective intervention at each cost level');
 		});
 
 		it('should include both Present and Long term series when newCases has data', () => {
 			const config = getCasesCompareConfig(compareTotals);
 
 			expect(config.series).toHaveLength(3);
-			expect((config.series as any)[0].name).toBe('Present');
-			expect((config.series as any)[1].name).toBe('Long term (baseline only)');
-			expect((config.series as any)[2].name).toBe('Long term (baseline + control strategy)');
+			expect((config.series as any)[0].name).toBe('Present (current control strategy)');
+			expect((config.series as any)[1].name).toBe('Long-term (current control strategy)');
+			expect((config.series as any)[2].name).toBe('Long-term (adjusted control strategy)');
 		});
 
 		it('should include only Present series when newCases is empty', () => {
@@ -517,7 +517,7 @@ describe('cases compare config', () => {
 			});
 
 			expect(config.series).toHaveLength(1);
-			expect((config.series as any)[0].name).toBe('Present');
+			expect((config.series as any)[0].name).toBe('Present (current control strategy)');
 		});
 
 		it('should apply breaks to xAxis when data points exist', () => {

--- a/client/src/tests/lib/charts/prevalenceConfig.spec.ts
+++ b/client/src/tests/lib/charts/prevalenceConfig.spec.ts
@@ -181,9 +181,9 @@ describe('getPrevalenceConfigCompare', () => {
 		const series = config.series as Highcharts.SeriesSplineOptions[];
 
 		expect(series).toHaveLength(3);
-		expect(series[0].name).toBe('Present');
-		expect(series[1].name).toBe('Long term (baseline only)');
-		expect(series[2].name).toContain('Long term (baseline + control strategy)');
+		expect(series[0].name).toBe('Present (current control strategy)');
+		expect(series[1].name).toBe('Long-term (current control strategy)');
+		expect(series[2].name).toContain('Long-term (adjusted control strategy)');
 	});
 
 	it('should handle empty long term data', () => {
@@ -198,7 +198,7 @@ describe('getPrevalenceConfigCompare', () => {
 		const series = config.series as Highcharts.SeriesSplineOptions[];
 
 		expect(series).toHaveLength(1);
-		expect(series[0].name).toBe('Present');
+		expect(series[0].name).toBe('Present (current control strategy)');
 	});
 	it('should have selected intervention in title', () => {
 		const config = getPrevalenceConfigCompare(

--- a/client/src/tests/lib/charts/prevalenceConfig.spec.ts
+++ b/client/src/tests/lib/charts/prevalenceConfig.spec.ts
@@ -181,9 +181,9 @@ describe('getPrevalenceConfigCompare', () => {
 		const series = config.series as Highcharts.SeriesSplineOptions[];
 
 		expect(series).toHaveLength(3);
-		expect(series[0].name).toBe('Present (current control strategy)');
-		expect(series[1].name).toBe('Long-term (current control strategy)');
-		expect(series[2].name).toContain('Long-term (adjusted control strategy)');
+		expect(series[0].name).toBe('Present (current control strategies)');
+		expect(series[1].name).toBe('Long-term (current control strategies)');
+		expect(series[2].name).toContain('Long-term (adjusted control strategies)');
 	});
 
 	it('should handle empty long term data', () => {
@@ -198,7 +198,7 @@ describe('getPrevalenceConfigCompare', () => {
 		const series = config.series as Highcharts.SeriesSplineOptions[];
 
 		expect(series).toHaveLength(1);
-		expect(series[0].name).toBe('Present (current control strategy)');
+		expect(series[0].name).toBe('Present (current control strategies)');
 	});
 	it('should have selected intervention in title', () => {
 		const config = getPrevalenceConfigCompare(

--- a/client/src/tests/lib/charts/strategyConfig.spec.ts
+++ b/client/src/tests/lib/charts/strategyConfig.spec.ts
@@ -69,7 +69,7 @@ describe('getStrategyConfig', () => {
 
 		expect(config.chart?.type).toBe('area');
 		expect(config.chart?.height).toBe(450);
-		expect(config.title?.text).toBe('Total Cases Averted vs Total Budget');
+		expect(config.title?.text).toBe('Total Clinical Cases Averted and Cost of Strategy');
 	});
 
 	it('should configure xAxis with min and explored budget plotline', () => {

--- a/client/src/tests/lib/components/FieldWithChange.svelte.spec.ts
+++ b/client/src/tests/lib/components/FieldWithChange.svelte.spec.ts
@@ -32,6 +32,7 @@ describe('FieldWithChange component', () => {
 
 		await expect.element(screen.getByText('50.0%')).toBeVisible();
 	});
+
 	it("should render -ve change with '-' sign", async () => {
 		const screen = render(FieldWithChange, {
 			value: 0,
@@ -44,5 +45,20 @@ describe('FieldWithChange component', () => {
 		} as any);
 
 		await expect.element(screen.getByText('-')).toBeVisible();
+	});
+
+	it('should render invert sign for change when invertSign is true', async () => {
+		const screen = render(FieldWithChange, {
+			value: 0,
+			baseline: 5,
+			prefixUnit: '$',
+			postfixUnit: '%',
+			invertSign: true,
+			children: createRawSnippet(() => ({
+				render: () => '<div>Child Content</div>'
+			}))
+		} as any);
+
+		await expect.element(screen.getByText('+')).toBeVisible();
 	});
 });

--- a/client/src/tests/lib/tables/compareCasesTable.spec.ts
+++ b/client/src/tests/lib/tables/compareCasesTable.spec.ts
@@ -137,9 +137,9 @@ describe('compareCasesTable', () => {
 	it('compareCasesTableColumns contains expected top-level groups', () => {
 		expect(compareCasesTableColumns.map((c: any) => c.header)).toEqual([
 			'Intervention',
-			'Present',
-			'Long term (baseline only)',
-			'Long term (baseline + control strategy)'
+			'Present (current control strategy)',
+			'Long-term (current control strategy)',
+			'Long-term (adjusted control strategy)'
 		]);
 	});
 

--- a/client/src/tests/lib/tables/compareCasesTable.spec.ts
+++ b/client/src/tests/lib/tables/compareCasesTable.spec.ts
@@ -137,9 +137,9 @@ describe('compareCasesTable', () => {
 	it('compareCasesTableColumns contains expected top-level groups', () => {
 		expect(compareCasesTableColumns.map((c: any) => c.header)).toEqual([
 			'Intervention',
-			'Present (current control strategy)',
-			'Long-term (current control strategy)',
-			'Long-term (adjusted control strategy)'
+			'Present (current control strategies)',
+			'Long-term (current control strategies)',
+			'Long-term (adjusted control strategies)'
 		]);
 	});
 

--- a/client/src/tests/mocks/mocks.ts
+++ b/client/src/tests/mocks/mocks.ts
@@ -586,7 +586,8 @@ export const MOCK_COMPARE_PARAMETERS: Readonly<CompareParameters> = Object.freez
 				{
 					costName: 'irs_household_annual_cost_deployment',
 					costLabel: 'IRS annual household cost deployment',
-					step: 0.1
+					step: 0.1,
+					costDecreasesWithIncrease: false
 				}
 			]
 		},
@@ -596,7 +597,14 @@ export const MOCK_COMPARE_PARAMETERS: Readonly<CompareParameters> = Object.freez
 			min: 0,
 			max: 100,
 			step: 1,
-			linkedCosts: [{ costName: 'mass_distribution_cost', costLabel: 'Mass distribution cost', step: 0.1 }]
+			linkedCosts: [
+				{
+					costName: 'mass_distribution_cost',
+					costLabel: 'Mass distribution cost',
+					step: 0.1,
+					costDecreasesWithIncrease: false
+				}
+			]
 		},
 		{
 			parameterName: 'lsm',
@@ -604,7 +612,7 @@ export const MOCK_COMPARE_PARAMETERS: Readonly<CompareParameters> = Object.freez
 			min: 0,
 			max: 90,
 			step: 1,
-			linkedCosts: [{ costName: 'lsm_cost', costLabel: 'LSM annual cost', step: 0.1 }]
+			linkedCosts: [{ costName: 'lsm_cost', costLabel: 'LSM annual cost', step: 0.1, costDecreasesWithIncrease: false }]
 		}
 	]
 });

--- a/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
@@ -49,12 +49,12 @@ describe('Compare CompareResults component', () => {
 		await expect.element(screen.getByRole('region', { name: 'prevalence compare graph' })).toBeVisible();
 		await expect.element(screen.getByRole('region', { name: 'cases compare graph' })).toBeVisible();
 
-		const presentLegendLabels = screen.getByRole('button', { name: 'Show Present (current control strategy)' }).all();
+		const presentLegendLabels = screen.getByRole('button', { name: 'Show Present (current control strategies)' }).all();
 		const baselineLongTermLegendLabels = screen
-			.getByRole('button', { name: 'Show Long-term (current control strategy)' })
+			.getByRole('button', { name: 'Show Long-term (current control strategies)' })
 			.all();
 		const fullLongTermLegendLabels = screen
-			.getByRole('button', { name: 'Show Long-term (adjusted control strategy)' })
+			.getByRole('button', { name: 'Show Long-term (adjusted control strategies)' })
 			.all();
 		// cases + prevalence for each of the 3 series types
 		for (let i = 0; i < 2; i++) {
@@ -71,13 +71,13 @@ describe('Compare CompareResults component', () => {
 
 		await expect.element(screen.getByRole('columnheader', { name: 'Intervention' })).toBeVisible();
 		await expect
-			.element(screen.getByRole('columnheader', { name: 'Present (current control strategy)' }))
+			.element(screen.getByRole('columnheader', { name: 'Present (current control strategies)' }))
 			.toBeVisible();
 		await expect
-			.element(screen.getByRole('columnheader', { name: 'Long-term (current control strategy)' }))
+			.element(screen.getByRole('columnheader', { name: 'Long-term (current control strategies)' }))
 			.toBeVisible();
 		await expect
-			.element(screen.getByRole('columnheader', { name: 'Long-term (adjusted control strategy)' }))
+			.element(screen.getByRole('columnheader', { name: 'Long-term (adjusted control strategies)' }))
 			.toBeVisible();
 	});
 

--- a/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte.spec.ts
@@ -49,10 +49,12 @@ describe('Compare CompareResults component', () => {
 		await expect.element(screen.getByRole('region', { name: 'prevalence compare graph' })).toBeVisible();
 		await expect.element(screen.getByRole('region', { name: 'cases compare graph' })).toBeVisible();
 
-		const presentLegendLabels = screen.getByRole('button', { name: 'Show Present' }).all();
-		const baselineLongTermLegendLabels = screen.getByRole('button', { name: 'Show Long Term (baseline only)' }).all();
+		const presentLegendLabels = screen.getByRole('button', { name: 'Show Present (current control strategy)' }).all();
+		const baselineLongTermLegendLabels = screen
+			.getByRole('button', { name: 'Show Long-term (current control strategy)' })
+			.all();
 		const fullLongTermLegendLabels = screen
-			.getByRole('button', { name: 'Show Long Term (baseline + control strategy)' })
+			.getByRole('button', { name: 'Show Long-term (adjusted control strategy)' })
 			.all();
 		// cases + prevalence for each of the 3 series types
 		for (let i = 0; i < 2; i++) {
@@ -68,10 +70,14 @@ describe('Compare CompareResults component', () => {
 		await screen.getByRole('tab', { name: 'Table' }).click();
 
 		await expect.element(screen.getByRole('columnheader', { name: 'Intervention' })).toBeVisible();
-		await expect.element(screen.getByRole('columnheader', { name: 'Present' })).toBeVisible();
-		await expect.element(screen.getByRole('columnheader', { name: 'Long term (baseline only)' })).toBeVisible();
 		await expect
-			.element(screen.getByRole('columnheader', { name: 'Long term (baseline + control strategy)' }))
+			.element(screen.getByRole('columnheader', { name: 'Present (current control strategy)' }))
+			.toBeVisible();
+		await expect
+			.element(screen.getByRole('columnheader', { name: 'Long-term (current control strategy)' }))
+			.toBeVisible();
+		await expect
+			.element(screen.getByRole('columnheader', { name: 'Long-term (adjusted control strategy)' }))
 			.toBeVisible();
 	});
 

--- a/client/src/tests/routes/projects/[project]/regions/[region]/page.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/regions/[region]/page.svelte.spec.ts
@@ -95,7 +95,7 @@ describe('page.svelte', () => {
 			}
 		} as any);
 
-		await expect.element(screen.getByRole('heading', { name: 'Projected prevalence in under' })).toBeVisible();
+		await expect.element(screen.getByRole('heading', { name: 'Prevalence (0-5 years)' })).toBeVisible();
 		await expect.element(screen.getByRole('heading', { name: 'Clinical cases averted per' })).toBeVisible();
 	});
 

--- a/client/src/tests/routes/projects/[project]/strategise/_components/StrategiseResults.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/strategise/_components/StrategiseResults.svelte.spec.ts
@@ -52,7 +52,7 @@ describe('StrategiseResults', () => {
 			}
 		} as any);
 
-		await expect.element(screen.getByRole('heading', { name: 'Total Cases Averted vs Total' })).toBeVisible();
+		await expect.element(screen.getByRole('heading', { name: 'Total Clinical Cases Averted' })).toBeVisible();
 		await expect.element(screen.getByRole('button', { name: 'Show Region A' })).toBeVisible();
 		await expect.element(screen.getByRole('button', { name: 'Show Region B' })).toBeVisible();
 		await expect.element(screen.getByRole('heading', { name: 'Optimal Strategy for selected' })).toBeVisible();

--- a/server-python/app/models.py
+++ b/server-python/app/models.py
@@ -125,6 +125,7 @@ class InterventionCompareCost(BaseModel):
     step: float
     cost_decreases_with_increase: bool = Field(serialization_alias="costDecreasesWithIncrease")
 
+
 class InterventionCompareParameter(CompareParameter):
     linked_costs: list[InterventionCompareCost] = Field(serialization_alias="linkedCosts")
 
@@ -132,3 +133,13 @@ class InterventionCompareParameter(CompareParameter):
 class CompareParametersResponse(BaseModel):
     baseline_parameters: list[CompareParameter] = Field(serialization_alias="baselineParameters")
     intervention_parameters: list[InterventionCompareParameter] = Field(serialization_alias="interventionParameters")
+
+
+class BaselineParameterOption(BaseModel):
+    name: str
+    label: str
+
+
+class InterventionParameterOption(BaseModel):
+    name: str
+    linked_costs: list[tuple[str, bool]]

--- a/server-python/app/models.py
+++ b/server-python/app/models.py
@@ -123,7 +123,7 @@ class InterventionCompareCost(BaseModel):
     cost_name: str = Field(serialization_alias="costName")
     cost_label: str = Field(serialization_alias="costLabel")
     step: float
-
+    cost_decreases_with_increase: bool = Field(serialization_alias="costDecreasesWithIncrease")
 
 class InterventionCompareParameter(CompareParameter):
     linked_costs: list[InterventionCompareCost] = Field(serialization_alias="linkedCosts")

--- a/server-python/app/resources/dynamicFormOptions.json
+++ b/server-python/app/resources/dynamicFormOptions.json
@@ -309,7 +309,7 @@
               "type": "number",
               "required": true,
               "default": 1.8,
-              "step": 0.1
+              "step": 0.01
             },
             {
               "id": "people_per_household",
@@ -348,7 +348,7 @@
               "type": "number",
               "required": true,
               "default": 1.85,
-              "step": 0.1
+              "step": 0.01
             },
             {
               "id": "py_pbo_cost",
@@ -356,7 +356,7 @@
               "type": "number",
               "required": true,
               "default": 2.14,
-              "step": 0.1
+              "step": 0.01
             },
             {
               "id": "py_pyrrole_cost",
@@ -364,7 +364,7 @@
               "type": "number",
               "required": true,
               "default": 2.56,
-              "step": 0.1
+              "step": 0.01
             },
             {
               "id": "py_ppf_cost",
@@ -372,7 +372,7 @@
               "type": "number",
               "required": true,
               "default": 2.86,
-              "step": 0.1
+              "step": 0.01
             },
             {
               "id": "mass_distribution_cost",
@@ -381,7 +381,7 @@
               "type": "number",
               "required": true,
               "default": 2.75,
-              "step": 0.1
+              "step": 0.01
             },
             {
               "id": "continuous_itn_distribution_cost",
@@ -390,7 +390,7 @@
               "type": "number",
               "required": true,
               "default": 2.75,
-              "step": 0.1
+              "step": 0.01
             },
             {
               "id": "irs_household_annual_cost_product",
@@ -398,7 +398,8 @@
               "helpText": "This is the cost of the IRS products needed to spray an average sized household structure (as defined by the user in the Procurement and Distribution Options section above).",
               "type": "number",
               "required": true,
-              "default": 12
+              "default": 12,
+              "step": 0.01
             },
             {
               "id": "irs_household_annual_cost_deployment",
@@ -406,7 +407,8 @@
               "helpText": "This is the logistics costs involved with spraying an average sized household structure (as defined by the user in the Procurement and Distribution Options section above).",
               "type": "number",
               "required": true,
-              "default": 12
+              "default": 12,
+              "step": 0.01
             },
             {
               "id": "lsm_cost",
@@ -414,7 +416,8 @@
               "helpText": "This is the estimated total cost to conduct an LSM programme that will achieve the reduction in mosquito density defined in the Intervention Options section above, divided by the population size for this region.",
               "type": "number",
               "required": true,
-              "default": 10
+              "default": 10,
+              "step": 0.01
             }
           ]
         }

--- a/server-python/app/services/resources.py
+++ b/server-python/app/services/resources.py
@@ -31,23 +31,28 @@ def get_dynamic_form_options() -> dict:
 
 def get_compare_parameters() -> CompareParametersResponse:
     form_options = get_dynamic_form_options()
-    baseline_param_names = [
-        ("current_malaria_prevalence", "Baseline prevalence"),
-        ("mosquito_delta", "Change in human biting rate"),
+    baseline_param_options = [
+        {"name": "current_malaria_prevalence", "label": "Prevalence (0-5 year olds)"},
+        {"name": "mosquito_delta", "label": "Human Biting Rate (all ages)"},
     ]
-    intervention_param_names = [
-        (
-            "itn_future",
-            "ITN usage",
-            ["people_per_bednet", "mass_distribution_cost", "continuous_itn_distribution_cost"],
-        ),
-        ("irs_future", "IRS coverage", ["irs_household_annual_cost_product", "irs_household_annual_cost_deployment"]),
-        ("lsm", "LSM coverage", ["lsm_cost"]),
+    intervention_param_options = [
+        {
+            "name": "itn_future",
+            "linked_costs": [("people_per_bednet", True), ("mass_distribution_cost", False), ("continuous_itn_distribution_cost", False)]
+        },
+        {
+            "name": "irs_future",
+            "linked_costs": [("irs_household_annual_cost_product", False), ("irs_household_annual_cost_deployment", False)]
+        },
+        {
+            "name": "lsm",
+            "linked_costs": [("lsm_cost", False)]
+        },
     ]
 
-    baseline_parameters = [create_compare_parameter(param_name, form_options) for param_name in baseline_param_names]
+    baseline_parameters = [create_compare_parameter(param, form_options) for param in baseline_param_options]
     intervention_parameters = [
-        create_intervention_compare_parameter(param_name, form_options) for param_name in intervention_param_names
+        create_intervention_compare_parameter(param, form_options) for param in intervention_param_options
     ]
 
     return CompareParametersResponse(
@@ -57,32 +62,35 @@ def get_compare_parameters() -> CompareParametersResponse:
 
 
 def create_intervention_compare_parameter(
-    param: Annotated[tuple[str, str, list[str]], "parameter name, label, linked cost names"],
+    param: Annotated[dict[str, str | list[tuple[str, bool]]], "name, linked costs [(linked cost name, cost_decreases_with_increase)]"],
     form_options: dict,
 ) -> InterventionCompareParameter:
-    param_name, label, linked_cost_names = param
-    cost_fields = [get_form_field(cost_name, form_options) for cost_name in linked_cost_names]
+    name, linked_costs_config = param["name"], param["linked_costs"]
+    intervention_field = get_form_field(name, form_options)
+    cost_fields = [(get_form_field(cost_name, form_options), cost_decreases_with_increase) for cost_name, cost_decreases_with_increase in linked_costs_config]
     linked_costs = [
         InterventionCompareCost(
             cost_name=cost_field["id"],
             cost_label=cost_field.get("label", cost_field["id"]),
             step=cost_field.get("step", 1.0),
+            cost_decreases_with_increase=cost_decreases_with_increase,
         )
-        for cost_field in cost_fields
+        for cost_field, cost_decreases_with_increase in cost_fields
     ]
+
     return InterventionCompareParameter(
-        **create_compare_parameter((param_name, label), form_options).model_dump(),
+        **create_compare_parameter({"name": name, "label": intervention_field.get("label", name)}, form_options).model_dump(),
         linked_costs=linked_costs,
     )
 
 
 def create_compare_parameter(
-    param: Annotated[tuple[str, str], "parameter name, label"], form_options: dict
+    param: Annotated[dict[str, str], "parameter name, label"], form_options: dict
 ) -> CompareParameter:
-    param_name, label = param
-    field = get_form_field(param_name, form_options)
+    name, label = param["name"], param["label"]
+    field = get_form_field(name, form_options)
     return CompareParameter(
-        parameter_name=param_name,
+        parameter_name=name,
         label=label,
         min=field.get("min", 0.0),
         max=field.get("max", 100.0),

--- a/server-python/app/services/resources.py
+++ b/server-python/app/services/resources.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Annotated
 
 import jsonschema
 

--- a/server-python/app/services/resources.py
+++ b/server-python/app/services/resources.py
@@ -5,10 +5,12 @@ from typing import Annotated
 import jsonschema
 
 from app.models import (
+    BaselineParameterOption,
     CompareParameter,
     CompareParametersResponse,
     InterventionCompareCost,
     InterventionCompareParameter,
+    InterventionParameterOption,
 )
 
 APP_DIR = Path(__file__).parent.parent
@@ -32,22 +34,26 @@ def get_dynamic_form_options() -> dict:
 def get_compare_parameters() -> CompareParametersResponse:
     form_options = get_dynamic_form_options()
     baseline_param_options = [
-        {"name": "current_malaria_prevalence", "label": "Prevalence (0-5 year olds)"},
-        {"name": "mosquito_delta", "label": "Human Biting Rate (all ages)"},
+        BaselineParameterOption(name="current_malaria_prevalence", label="Prevalence (0-5 year olds)"),
+        BaselineParameterOption(name="mosquito_delta", label="Human Biting Rate (all ages)"),
     ]
     intervention_param_options = [
-        {
-            "name": "itn_future",
-            "linked_costs": [("people_per_bednet", True), ("mass_distribution_cost", False), ("continuous_itn_distribution_cost", False)]
-        },
-        {
-            "name": "irs_future",
-            "linked_costs": [("irs_household_annual_cost_product", False), ("irs_household_annual_cost_deployment", False)]
-        },
-        {
-            "name": "lsm",
-            "linked_costs": [("lsm_cost", False)]
-        },
+        InterventionParameterOption(
+            name="itn_future",
+            linked_costs=[
+                ("people_per_bednet", True),
+                ("mass_distribution_cost", False),
+                ("continuous_itn_distribution_cost", False),
+            ],
+        ),
+        InterventionParameterOption(
+            name="irs_future",
+            linked_costs=[
+                ("irs_household_annual_cost_product", False),
+                ("irs_household_annual_cost_deployment", False),
+            ],
+        ),
+        InterventionParameterOption(name="lsm", linked_costs=[("lsm_cost", False)]),
     ]
 
     baseline_parameters = [create_compare_parameter(param, form_options) for param in baseline_param_options]
@@ -62,12 +68,15 @@ def get_compare_parameters() -> CompareParametersResponse:
 
 
 def create_intervention_compare_parameter(
-    param: Annotated[dict[str, str | list[tuple[str, bool]]], "name, linked costs [(linked cost name, cost_decreases_with_increase)]"],
+    param: InterventionParameterOption,
     form_options: dict,
 ) -> InterventionCompareParameter:
-    name, linked_costs_config = param["name"], param["linked_costs"]
+    name, linked_costs_config = param.name, param.linked_costs
     intervention_field = get_form_field(name, form_options)
-    cost_fields = [(get_form_field(cost_name, form_options), cost_decreases_with_increase) for cost_name, cost_decreases_with_increase in linked_costs_config]
+    cost_fields = [
+        (get_form_field(cost_name, form_options), cost_decreases_with_increase)
+        for cost_name, cost_decreases_with_increase in linked_costs_config
+    ]
     linked_costs = [
         InterventionCompareCost(
             cost_name=cost_field["id"],
@@ -79,15 +88,15 @@ def create_intervention_compare_parameter(
     ]
 
     return InterventionCompareParameter(
-        **create_compare_parameter({"name": name, "label": intervention_field.get("label", name)}, form_options).model_dump(),
+        **create_compare_parameter(
+            BaselineParameterOption(name=name, label=intervention_field.get("label", name)), form_options
+        ).model_dump(),
         linked_costs=linked_costs,
     )
 
 
-def create_compare_parameter(
-    param: Annotated[dict[str, str], "parameter name, label"], form_options: dict
-) -> CompareParameter:
-    name, label = param["name"], param["label"]
+def create_compare_parameter(param: BaselineParameterOption, form_options: dict) -> CompareParameter:
+    name, label = param.name, param.label
     field = get_form_field(name, form_options)
     return CompareParameter(
         parameter_name=name,

--- a/server-python/tests/services/test_resources.py
+++ b/server-python/tests/services/test_resources.py
@@ -6,10 +6,12 @@ import jsonschema
 import pytest
 
 from app.models import (
+    BaselineParameterOption,
     CompareParameter,
     CompareParametersResponse,
     InterventionCompareCost,
     InterventionCompareParameter,
+    InterventionParameterOption,
 )
 from app.services.resources import (
     create_compare_parameter,
@@ -102,7 +104,7 @@ class TestCreateCompareParameter:
                             {"id": "current_malaria_prevalence", "min": 2, "max": 70},
                             {"id": "preference_for_biting_in_bed", "min": 40, "max": 90},
                             {"id": "no_min_max_field"},
-                            {"id": "itn_future"},
+                            {"id": "itn_future", "label": "ITN Future"},
                             {"id": "itn_cost1", "label": "ITN Cost 1"},
                             {"id": "itn_cost2", "label": "ITN Cost 2"},
                         ]
@@ -122,7 +124,7 @@ class TestCreateCompareParameter:
             get_form_field("non_existent_field", self.form_options)
 
     def test_create_compare_parameter(self):
-        param = ("current_malaria_prevalence", "Prevalence")
+        param = BaselineParameterOption(name="current_malaria_prevalence", label="Prevalence")
 
         compare_param = create_compare_parameter(param, self.form_options)
 
@@ -135,7 +137,7 @@ class TestCreateCompareParameter:
         }
 
     def test_create_compare_parameter_no_min_max(self):
-        param = ("no_min_max_field", "No Min Max")
+        param = BaselineParameterOption(name="no_min_max_field", label="No Min Max")
 
         compare_param = create_compare_parameter(param, self.form_options)
 
@@ -148,19 +150,29 @@ class TestCreateCompareParameter:
         }
 
     def test_create_intervention_compare_parameter(self):
-        param = ("itn_future", "ITN Usage", ["itn_cost1", "itn_cost2"])
+        param = InterventionParameterOption(name="itn_future", linked_costs=[("itn_cost1", True), ("itn_cost2", False)])
 
         intervention_compare_param = create_intervention_compare_parameter(param, self.form_options)
 
         assert intervention_compare_param.model_dump() == {
             "parameter_name": "itn_future",
-            "label": "ITN Usage",
+            "label": "ITN Future",
             "min": 0.0,
             "max": 100.0,
             "step": 1.0,
             "linked_costs": [
-                {"cost_name": "itn_cost1", "cost_label": "ITN Cost 1", "step": 1.0},
-                {"cost_name": "itn_cost2", "cost_label": "ITN Cost 2", "step": 1.0},
+                {
+                    "cost_name": "itn_cost1",
+                    "cost_label": "ITN Cost 1",
+                    "step": 1.0,
+                    "cost_decreases_with_increase": True,
+                },
+                {
+                    "cost_name": "itn_cost2",
+                    "cost_label": "ITN Cost 2",
+                    "step": 1.0,
+                    "cost_decreases_with_increase": False,
+                },
             ],
         }
 
@@ -197,8 +209,9 @@ class TestGetCompareParameters:
                 linked_costs=[
                     InterventionCompareCost(
                         cost_name="irs_household_annual_cost_product",
-                        cost_label="IRSHousehold Annual Cost Product",
+                        cost_label="IRS Household Annual Cost Product",
                         step=1.0,
+                        cost_decreases_with_increase=False,
                     )
                 ],
             ),
@@ -210,7 +223,10 @@ class TestGetCompareParameters:
                 step=1.0,
                 linked_costs=[
                     InterventionCompareCost(
-                        cost_name="mass_distribution_cost", cost_label="Mass Distribution Cost", step=1.0
+                        cost_name="mass_distribution_cost",
+                        cost_label="Mass Distribution Cost",
+                        step=1.0,
+                        cost_decreases_with_increase=False,
                     ),
                 ],
             ),
@@ -220,7 +236,11 @@ class TestGetCompareParameters:
                 min=0,
                 max=100,
                 step=1.0,
-                linked_costs=[InterventionCompareCost(cost_name="lsm_cost", cost_label="LSM Cost", step=1.0)],
+                linked_costs=[
+                    InterventionCompareCost(
+                        cost_name="lsm_cost", cost_label="LSM Cost", step=1.0, cost_decreases_with_increase=False
+                    )
+                ],
             ),
         ]
         mock_options.return_value = options
@@ -231,27 +251,32 @@ class TestGetCompareParameters:
 
         mock_options.assert_called_once()
         expected_compare_calls = [
-            (("current_malaria_prevalence", "Baseline prevalence"), options),
-            (("mosquito_delta", "Change in human biting rate"), options),
+            (BaselineParameterOption(name="current_malaria_prevalence", label="Prevalence (0-5 year olds)"), options),
+            (BaselineParameterOption(name="mosquito_delta", label="Human Biting Rate (all ages)"), options),
         ]
         expected_intervention_compare_calls = [
             (
-                (
-                    "itn_future",
-                    "ITN usage",
-                    ["people_per_bednet", "mass_distribution_cost", "continuous_itn_distribution_cost"],
+                InterventionParameterOption(
+                    name="itn_future",
+                    linked_costs=[
+                        ("people_per_bednet", True),
+                        ("mass_distribution_cost", False),
+                        ("continuous_itn_distribution_cost", False),
+                    ],
                 ),
                 options,
             ),
             (
-                (
-                    "irs_future",
-                    "IRS coverage",
-                    ["irs_household_annual_cost_product", "irs_household_annual_cost_deployment"],
+                InterventionParameterOption(
+                    name="irs_future",
+                    linked_costs=[
+                        ("irs_household_annual_cost_product", False),
+                        ("irs_household_annual_cost_deployment", False),
+                    ],
                 ),
                 options,
             ),
-            (("lsm", "LSM coverage", ["lsm_cost"]), options),
+            (InterventionParameterOption(name="lsm", linked_costs=[("lsm_cost", False)]), options),
         ]
         actual_compare_calls = [call.args for call in mock_compare.call_args_list]
         actual_intervention_compare_calls = [call.args for call in mock_intervention_compare.call_args_list]

--- a/server-python/tests/test_models.py
+++ b/server-python/tests/test_models.py
@@ -264,8 +264,12 @@ class TestCompareParametersResponse:
                 max=70.0,
                 step=1.0,
                 linked_costs=[
-                    InterventionCompareCost(cost_name="cost3", cost_label="Cost 3", step=1.0),
-                    InterventionCompareCost(cost_name="cost4", cost_label="Cost 4", step=1.0),
+                    InterventionCompareCost(
+                        cost_name="cost3", cost_label="Cost 3", step=1.0, cost_decreases_with_increase=True
+                    ),
+                    InterventionCompareCost(
+                        cost_name="cost4", cost_label="Cost 4", step=1.0, cost_decreases_with_increase=False
+                    ),
                 ],
             ),
         ]
@@ -278,8 +282,9 @@ class TestCompareParametersResponse:
         assert response.baseline_parameters[0].parameter_name == "param1"
         assert response.intervention_parameters[0].label == "Parameter 3"
         assert {
-            (cost.cost_name, cost.cost_label, cost.step) for cost in response.intervention_parameters[0].linked_costs
+            (cost.cost_name, cost.cost_label, cost.step, cost.cost_decreases_with_increase)
+            for cost in response.intervention_parameters[0].linked_costs
         } == {
-            ("cost3", "Cost 3", 1.0),
-            ("cost4", "Cost 4", 1.0),
+            ("cost3", "Cost 3", 1.0, True),
+            ("cost4", "Cost 4", 1.0, False),
         }


### PR DESCRIPTION
The following is feedback recieved from tom. ive attached screenshots if you wanted to check. Mostly naming changes. The main one is that for people per itn, we want to show -ve % when we increase the number as the cost is decreasing and visa versa.



<img width="752" height="813" alt="image" src="https://github.com/user-attachments/assets/31a0e2c3-723f-4e55-a617-4f316720fa79" />
<img width="752" height="813" alt="image" src="https://github.com/user-attachments/assets/2fcb800c-79dd-4399-9c19-bcedd8b51bc0" />

