### PR TITLE
Alternative strategise view

### DIFF
--- a/client/e2e/strategise.test.ts
+++ b/client/e2e/strategise.test.ts
@@ -48,8 +48,26 @@ test.describe('Strategise page', () => {
 		).toBeVisible();
 
 		// individual region cards
-		await expect(page.getByText('Pop: 20,000 nz LSM Only Cost')).toBeVisible();
-		await expect(page.getByText('Pop: 20,000 australia LSM Only Cost')).toBeVisible();
+		await expect(page.getByLabel('Cases Averted Chart').getByText('Pop: 20,000 nz LSM Only Cost')).toBeVisible();
+		await expect(page.getByLabel('Cases Averted Chart').getByText('Pop: 20,000 australia LSM Only Cost')).toBeVisible();
+	});
+
+	test('should be able to see strategise grid allocation view', async ({ page }) => {
+		await goto(page, `/projects/${projectName}/regions/nz`);
+		await runRegionWithLSM(page);
+
+		await goto(page, `/projects/${projectName}/regions/australia`);
+		await runRegionWithLSM(page);
+
+		await page.getByRole('link', { name: 'Sub-national tailoring' }).click();
+
+		await page.getByRole('button', { name: 'Explore defined budget range' }).click();
+
+		await page.getByRole('tab', { name: 'Allocation Grid' }).click();
+		await expect(page.getByRole('heading', { name: 'Intervention Allocation by' })).toBeVisible();
+		// individual region cards
+		await expect(page.getByLabel('Allocation Grid').getByText('Pop: 20,000 nz LSM Only Cost')).toBeVisible();
+		await expect(page.getByLabel('Allocation Grid').getByText('Pop: 20,000 australia LSM Only Cost')).toBeVisible();
 	});
 
 	test("should wipe strategise data when a region's interventions are re-run", async ({ page }) => {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -31,7 +31,7 @@
 				"@types/node": "^24.1.0",
 				"@vitest/browser-playwright": "^4.0.18",
 				"@vitest/coverage-v8": "^4.0.18",
-				"bits-ui": "^2.15.4",
+				"bits-ui": "^2.16.3",
 				"clsx": "^2.1.1",
 				"eslint": "^9.18.0",
 				"eslint-config-prettier": "^10.0.1",
@@ -2849,9 +2849,9 @@
 			"license": "MIT"
 		},
 		"node_modules/bits-ui": {
-			"version": "2.15.4",
-			"resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-2.15.4.tgz",
-			"integrity": "sha512-7H9YUfp03KOk1LVDh8wPYSRPxlZgG/GRWLNSA8QC73/8Z8ytun+DWJhIuibyFyz7A0cP/RANVcB4iDrbY8q+Og==",
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-2.16.3.tgz",
+			"integrity": "sha512-5hJ5dEhf5yPzkRFcxzgQHScGodeo0gK0MUUXrdLlRHWaBOBGZiacWLG96j/wwFatKwZvouw7q+sn14i0fx3RIg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
 		"@types/node": "^24.1.0",
 		"@vitest/browser-playwright": "^4.0.18",
 		"@vitest/coverage-v8": "^4.0.18",
-		"bits-ui": "^2.15.4",
+		"bits-ui": "^2.16.3",
 		"clsx": "^2.1.1",
 		"eslint": "^9.18.0",
 		"eslint-config-prettier": "^10.0.1",

--- a/client/src/lib/components/ui/tooltip/index.ts
+++ b/client/src/lib/components/ui/tooltip/index.ts
@@ -5,6 +5,7 @@ import Content from './tooltip-content.svelte';
 const Root = TooltipPrimitive.Root;
 const Provider = TooltipPrimitive.Provider;
 const Portal = TooltipPrimitive.Portal;
+const createTether = TooltipPrimitive.createTether;
 
 export {
 	Root,
@@ -17,5 +18,6 @@ export {
 	Content as TooltipContent,
 	Trigger as TooltipTrigger,
 	Provider as TooltipProvider,
-	Portal as TooltipPortal
+	Portal as TooltipPortal,
+	createTether
 };

--- a/client/src/lib/number.ts
+++ b/client/src/lib/number.ts
@@ -42,9 +42,9 @@ export const calculateRangePercent = (value: number, range: number): number => {
 	if (range === 0) return 0; // Avoid division by zero
 	return (value / range) * 100;
 };
-type NumericKeyOf<T> = {
-	[Key in keyof T]: T[Key] extends number ? Key : never;
-}[keyof T];
+type NumericKeyOf<T> = keyof {
+	[K in keyof T as T[K] extends number ? K : never]: T[K];
+};
 /**
  * Sums the values of a specified numeric key across an array of objects.
  *

--- a/client/src/lib/number.ts
+++ b/client/src/lib/number.ts
@@ -37,3 +37,8 @@ export const createLinearSpace = (min: number, max: number, count = 200): number
 
 	return result;
 };
+
+export const calculateRangePercent = (value: number, range: number): number => {
+	if (range === 0) return 0; // Avoid division by zero
+	return (value / range) * 100;
+};

--- a/client/src/lib/number.ts
+++ b/client/src/lib/number.ts
@@ -53,7 +53,6 @@ type NumericKeyOf<T> = keyof {
  * @param items - The array of objects to sum over
  * @param key - The key of the numeric property to sum
  * @returns The total sum of the specified numeric key across all objects in the array
- * @throws Will throw an error if the specified key is not numeric in any of the objects
  */
 export function sumByKey<T extends Record<string, unknown>, K extends NumericKeyOf<T>>(items: T[], key: K): number {
 	return items.reduce((total, item) => total + (item[key] as number), 0);

--- a/client/src/routes/projects/[project]/strategise/+page.svelte
+++ b/client/src/routes/projects/[project]/strategise/+page.svelte
@@ -88,7 +88,7 @@
 							strategiseResults={data.project.strategy.results}
 							populations={populationsOfRegion}
 							minCost={$formData.minCost}
-							maxCost={$formData.maxCost}
+							budget={$formData.budget}
 						/>
 					</Tabs.Content>
 					<Tabs.Content value="longTerm">
@@ -108,7 +108,7 @@
 					strategiseResults={data.project.strategy.results}
 					populations={populationsOfRegion}
 					minCost={$formData.minCost}
-					maxCost={$formData.maxCost}
+					budget={$formData.budget}
 				/>
 			{/if}
 		{/if}

--- a/client/src/routes/projects/[project]/strategise/+page.svelte
+++ b/client/src/routes/projects/[project]/strategise/+page.svelte
@@ -84,7 +84,12 @@
 						</Tabs.List>
 					</div>
 					<Tabs.Content value="present">
-						<StrategiseResults strategiseResults={data.project.strategy.results} populations={populationsOfRegion} />
+						<StrategiseResults
+							strategiseResults={data.project.strategy.results}
+							populations={populationsOfRegion}
+							minCost={$formData.minCost}
+							maxCost={$formData.maxCost}
+						/>
 					</Tabs.Content>
 					<Tabs.Content value="longTerm">
 						<div class="flex items-center justify-center">
@@ -99,7 +104,12 @@
 					</Tabs.Content>
 				</Tabs.Root>
 			{:else}
-				<StrategiseResults strategiseResults={data.project.strategy.results} populations={populationsOfRegion} />
+				<StrategiseResults
+					strategiseResults={data.project.strategy.results}
+					populations={populationsOfRegion}
+					minCost={$formData.minCost}
+					maxCost={$formData.maxCost}
+				/>
 			{/if}
 		{/if}
 	{:else}

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { ScenarioToLabel } from '$lib/charts/baseChart';
-	import type { Scenario, StrategiseResults } from '$lib/types/userState';
-	import { convertToLocaleString } from '$lib/number';
-	import { SvelteSet } from 'svelte/reactivity';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { convertToLocaleString } from '$lib/number';
+	import type { Scenario, StrategiseResults } from '$lib/types/userState';
+	import { SvelteSet } from 'svelte/reactivity';
 	import type { Block } from '../schema';
-	import { getFillStyle, createGridRows } from '../utils';
+	import { createGridRows, getFillStyle } from '../utils';
 
 	interface Props {
 		strategiseResults: StrategiseResults;
@@ -14,7 +14,7 @@
 	}
 	let { strategiseResults, minCost, maxCost }: Props = $props();
 
-	let regionTether = Tooltip.createTether();
+	let regionTether = Tooltip.createTether<Block>();
 	let costRange = $derived(maxCost - minCost);
 	let rows = $derived(createGridRows(strategiseResults, maxCost));
 
@@ -70,22 +70,32 @@
 						<!-- overflow-hidden clips blocks to the rounded container -->
 						<div class="relative h-8 overflow-hidden rounded-md">
 							<Tooltip.Root tether={regionTether}>
-								{#each row.blocks as block (block.startCost)}
-									<Tooltip.Trigger class="absolute inset-y-0 " style={getBlockStyle(block)} tether={regionTether} />
-									<Tooltip.Content
-										class="rounded-md bg-background/90 text-foreground/90 "
-										arrowClasses="bg-background/90"
-									>
-										<div class="flex flex-col gap-1">
-											<span class="font-medium">
-												{ScenarioToLabel[block.intervention]}
-											</span>
-											<span class="text-muted-foreground">
-												${convertToLocaleString(block.startCost, 0)} - ${convertToLocaleString(block.endCost, 0)}
-											</span>
-										</div>
-									</Tooltip.Content>
-								{/each}
+								{#snippet children({ payload })}
+									{#each row.blocks as block (block.startCost)}
+										<Tooltip.Trigger
+											class="absolute inset-y-0 "
+											style={getBlockStyle(block)}
+											tether={regionTether}
+											payload={block}
+										/>
+										<Tooltip.Content
+											class="rounded-md bg-background/90 text-foreground/90 "
+											arrowClasses="bg-background/90"
+										>
+											<div class="flex flex-col gap-1">
+												<span class="font-medium">
+													{ScenarioToLabel[payload!.intervention]}
+												</span>
+												<span class="text-muted-foreground">
+													${convertToLocaleString(payload!.startCost, 0)} - ${convertToLocaleString(
+														payload!.endCost,
+														0
+													)}
+												</span>
+											</div>
+										</Tooltip.Content>
+									{/each}
+								{/snippet}
 							</Tooltip.Root>
 						</div>
 					{/each}

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -33,8 +33,6 @@
 		const cost = minCost + costRange * clampedPercent;
 		const strategy = findClosestStrategiseResult(strategiseResults, cost);
 		selectStrategy(strategy);
-		const snappedPercent = calculateRangePercent(strategy.costThreshold - minCost, costRange);
-		selectedPercent = snappedPercent;
 	};
 
 	const getBlockStyle = (block: Block): string => {
@@ -108,13 +106,11 @@
 						{/each}
 					</div>
 				</Tooltip.Provider>
-				{#if selectedPercent !== null}
-					<div class="pointer-events-none absolute inset-y-0 -translate-x-1/2" style="left: {selectedPercent}%;">
-						<div class="h-full border border-dashed border-foreground"></div>
+				<div class="pointer-events-none absolute inset-y-0 -translate-x-1/2" style="left: {selectedPercent}%;">
+					<div class="h-full border border-dashed border-foreground"></div>
 
-						<span class="absolute -top-2 -translate-1/2 text-xs font-medium text-nowrap"> Explored budget </span>
-					</div>
-				{/if}
+					<span class="absolute -top-2 -translate-1/2 text-xs font-medium text-nowrap"> Explored budget </span>
+				</div>
 			</div>
 
 			<!-- X-axis ticks -->

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+	import { ScenarioToColor, ScenarioToLabel } from '$lib/charts/baseChart';
+	import type { Scenario, StrategiseResults } from '$lib/types/userState';
+	import { convertToLocaleString } from '$lib/number';
+	import { SvelteSet } from 'svelte/reactivity';
+
+	interface Props {
+		strategiseResults: StrategiseResults;
+	}
+	let { strategiseResults }: Props = $props();
+
+	interface Block {
+		intervention: Scenario;
+		startCost: number;
+		endCost: number;
+	}
+
+	interface RegionRow {
+		region: string;
+		blocks: Block[];
+	}
+
+	let minCost = $derived(strategiseResults[0]?.costThreshold ?? 0);
+	let maxCost = $derived(strategiseResults[strategiseResults.length - 1]?.costThreshold ?? 0);
+	let costRange = $derived(maxCost - minCost);
+
+	let regions = $derived.by(() => {
+		if (strategiseResults.length === 0) return [];
+		return strategiseResults[0].interventions.map((i) => i.region);
+	});
+
+	let rows = $derived.by((): RegionRow[] => {
+		return regions.map((region) => {
+			const blocks: Block[] = [];
+			let currentIntervention: Scenario | null = null;
+			let blockStart = 0;
+
+			for (let i = 0; i < strategiseResults.length; i++) {
+				const result = strategiseResults[i];
+				const intervention = result.interventions.find((inv) => inv.region === region);
+				if (!intervention) continue;
+
+				if (intervention.intervention !== currentIntervention) {
+					if (currentIntervention !== null) {
+						blocks.push({
+							intervention: currentIntervention,
+							startCost: blockStart,
+							endCost: result.costThreshold
+						});
+					}
+					currentIntervention = intervention.intervention;
+					blockStart = result.costThreshold;
+				}
+			}
+
+			if (currentIntervention !== null) {
+				blocks.push({
+					intervention: currentIntervention,
+					startCost: blockStart,
+					endCost: maxCost
+				});
+			}
+
+			return { region, blocks };
+		});
+	});
+
+	let legendItems = $derived.by(() => {
+		const seen = new SvelteSet<Scenario>();
+		for (const result of strategiseResults) {
+			for (const inv of result.interventions) {
+				seen.add(inv.intervention);
+			}
+		}
+		return seen;
+	});
+
+	function getWidthPercent(block: Block): number {
+		if (costRange === 0) return 100;
+		return ((block.endCost - block.startCost) / costRange) * 100;
+	}
+
+	function getLeftPercent(block: Block): number {
+		if (costRange === 0) return 0;
+		return ((block.startCost - minCost) / costRange) * 100;
+	}
+
+	// Matches the diagonal stripe direction of the SVG path in getColumnFill in baseChart.ts.
+	const LSM_STRIPE =
+		'repeating-linear-gradient(45deg, transparent, transparent 4px, var(--background) 4px, var(--background) 8px)';
+
+	function getFillStyle(scenario: Scenario): string {
+		const color = ScenarioToColor[scenario];
+		let style = `background-color: ${color};`;
+		if (scenario.includes('lsm')) {
+			style += ` background-image: ${LSM_STRIPE};`;
+		}
+		return style;
+	}
+
+	function getBlockStyle(block: Block): string {
+		const left = getLeftPercent(block);
+		const width = getWidthPercent(block);
+		const style = getFillStyle(block.intervention);
+		return `left: ${left}%; width: ${width}%; ${style}`;
+	}
+
+	const TICK_COUNT = 10;
+	let ticks = $derived.by(() => {
+		const result: number[] = [];
+		for (let i = 0; i <= TICK_COUNT; i++) {
+			result.push(minCost + (costRange * i) / TICK_COUNT);
+		}
+		return result;
+	});
+
+	function formatBudget(value: number): string {
+		if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+		if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}K`;
+		return `$${convertToLocaleString(value)}`;
+	}
+</script>
+
+<div class="mt-4 rounded-xl border bg-card p-6 shadow-sm">
+	<h3 class="mb-6 text-center text-lg font-semibold tracking-tight">Intervention Allocation by Budget Level</h3>
+
+	<div class="flex items-end gap-3">
+		<!-- Region labels -->
+		<div class="flex shrink-0 flex-col gap-2">
+			{#each rows as row (row.region)}
+				<div class="flex h-8 items-center justify-end text-right text-sm font-medium text-muted-foreground">
+					{row.region}
+				</div>
+			{/each}
+			<!-- spacer for x-axis -->
+			<div class="h-7"></div>
+		</div>
+
+		<!-- Grid + axis -->
+		<div class="min-w-0 flex-1">
+			<!-- Rows -->
+			<div class="flex flex-col gap-1.5">
+				{#each rows as row (row.region)}
+					<!-- overflow-hidden clips blocks to the rounded container -->
+					<div class="relative h-8 overflow-hidden rounded-md">
+						{#each row.blocks as block (block.startCost)}
+							<div
+								class="absolute inset-y-0"
+								style={getBlockStyle(block)}
+								title="{ScenarioToLabel[block.intervention]}: {formatBudget(block.startCost)} - {formatBudget(
+									block.endCost
+								)}"
+							></div>
+						{/each}
+					</div>
+				{/each}
+			</div>
+
+			<!-- X-axis ticks -->
+			<div class="relative mt-2 h-7 border-t border-border/60">
+				{#each ticks as tick, i (tick)}
+					{@const percentage = costRange === 0 ? 0 : ((tick - minCost) / costRange) * 100}
+					<div
+						class="absolute top-1.5 text-xs text-muted-foreground"
+						style="left: {percentage}%; transform: translateX({i === ticks.length - 1
+							? '-100%'
+							: i === 0
+								? '0%'
+								: '-50%'});"
+					>
+						{formatBudget(tick)}
+					</div>
+				{/each}
+			</div>
+		</div>
+	</div>
+
+	<!-- X-axis label -->
+	<div class="mt-1 text-center text-sm text-muted-foreground">Total cost ($USD)</div>
+
+	<!-- Legend -->
+	<div
+		class="mt-5 flex flex-wrap justify-center gap-x-5 gap-y-2 rounded-lg border border-border/50 bg-muted/20 px-4 py-3"
+	>
+		{#each legendItems as scenario (scenario)}
+			<div class="flex items-center gap-2 text-sm">
+				<div class="h-3.5 w-5 rounded" style={getFillStyle(scenario)}></div>
+				<span class="text-foreground/80">{ScenarioToLabel[scenario]}</span>
+			</div>
+		{/each}
+	</div>
+</div>

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -115,6 +115,7 @@
 	});
 
 	function formatBudget(value: number): string {
+		if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
 		if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
 		if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}K`;
 		return `$${convertToLocaleString(value)}`;
@@ -122,7 +123,7 @@
 </script>
 
 <div class="mt-4 rounded-xl border bg-card p-6 shadow-sm">
-	<h3 class="mb-6 text-center text-lg font-semibold tracking-tight">Intervention Allocation by Budget Level</h3>
+	<h3 class="mb-6 text-center text-lg font-semibold tracking-tight">Intervention Allocation by Cost of Strategy</h3>
 
 	<div class="flex items-end gap-3">
 		<!-- Region labels -->

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -3,6 +3,7 @@
 	import type { Scenario, StrategiseResults } from '$lib/types/userState';
 	import { convertToLocaleString } from '$lib/number';
 	import { SvelteSet } from 'svelte/reactivity';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 
 	interface Props {
 		strategiseResults: StrategiseResults;
@@ -20,6 +21,7 @@
 		blocks: Block[];
 	}
 
+	let triggerId = $state<string | null>(null);
 	let minCost = $derived(strategiseResults[0]?.costThreshold ?? 0);
 	let maxCost = $derived(strategiseResults[strategiseResults.length - 1]?.costThreshold ?? 0);
 	let costRange = $derived(maxCost - minCost);
@@ -85,9 +87,8 @@
 		return ((block.startCost - minCost) / costRange) * 100;
 	}
 
-	// Matches the diagonal stripe direction of the SVG path in getColumnFill in baseChart.ts.
 	const LSM_STRIPE =
-		'repeating-linear-gradient(45deg, transparent, transparent 4px, var(--background) 4px, var(--background) 8px)';
+		'repeating-linear-gradient(45deg, transparent, transparent 4px, var(--background) 7px, var(--background) 8px)';
 
 	function getFillStyle(scenario: Scenario): string {
 		const color = ScenarioToColor[scenario];
@@ -105,7 +106,11 @@
 		return `left: ${left}%; width: ${width}%; ${style}`;
 	}
 
-	const TICK_COUNT = 10;
+	function getBlockId(region: string, block: Block): string {
+		return `${region}::${block.startCost}::${block.endCost}::${block.intervention}`;
+	}
+
+	const TICK_COUNT = 8;
 	let ticks = $derived.by(() => {
 		const result: number[] = [];
 		for (let i = 0; i <= TICK_COUNT; i++) {
@@ -113,13 +118,6 @@
 		}
 		return result;
 	});
-
-	function formatBudget(value: number): string {
-		if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
-		if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
-		if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}K`;
-		return `$${convertToLocaleString(value)}`;
-	}
 </script>
 
 <div class="mt-4 rounded-xl border bg-card p-6 shadow-sm">
@@ -140,25 +138,42 @@
 		<!-- Grid + axis -->
 		<div class="min-w-0 flex-1">
 			<!-- Rows -->
-			<div class="flex flex-col gap-1.5">
-				{#each rows as row (row.region)}
-					<!-- overflow-hidden clips blocks to the rounded container -->
-					<div class="relative h-8 overflow-hidden rounded-md">
-						{#each row.blocks as block (block.startCost)}
-							<div
-								class="absolute inset-y-0"
-								style={getBlockStyle(block)}
-								title="{ScenarioToLabel[block.intervention]}: {formatBudget(block.startCost)} - {formatBudget(
-									block.endCost
-								)}"
-							></div>
-						{/each}
-					</div>
-				{/each}
-			</div>
+			<Tooltip.Provider delayDuration={200}>
+				<div class="flex flex-col gap-1.5">
+					{#each rows as row (row.region)}
+						<!-- overflow-hidden clips blocks to the rounded container -->
+						<div class="relative h-8 overflow-hidden rounded-md">
+							{#each row.blocks as block (block.startCost)}
+								{@const blockId = getBlockId(row.region, block)}
+								<Tooltip.Root
+									open={triggerId === blockId}
+									onOpenChange={(open) => {
+										triggerId = open ? blockId : triggerId === blockId ? null : triggerId;
+									}}
+								>
+									<Tooltip.Trigger class="absolute inset-y-0 cursor-pointer" style={getBlockStyle(block)} />
+									<Tooltip.Content
+										class="rounded-md bg-background/90 text-foreground/90 shadow-lg"
+										arrowClasses="bg-background/90"
+									>
+										<div class="flex flex-col gap-1">
+											<span class="font-medium">
+												{ScenarioToLabel[block.intervention]}
+											</span>
+											<span class="text-muted-foreground">
+												${convertToLocaleString(block.startCost, 0)} - ${convertToLocaleString(block.endCost, 0)}
+											</span>
+										</div>
+									</Tooltip.Content>
+								</Tooltip.Root>
+							{/each}
+						</div>
+					{/each}
+				</div>
+			</Tooltip.Provider>
 
 			<!-- X-axis ticks -->
-			<div class="relative mt-2 h-7 border-t border-border/60">
+			<div class="relative mt-1 h-7 border-t border-border/60">
 				{#each ticks as tick, i (tick)}
 					{@const percentage = costRange === 0 ? 0 : ((tick - minCost) / costRange) * 100}
 					<div
@@ -169,7 +184,7 @@
 								? '0%'
 								: '-50%'});"
 					>
-						{formatBudget(tick)}
+						${convertToLocaleString(tick, 0)}
 					</div>
 				{/each}
 			</div>

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -83,8 +83,8 @@
 		<div class="min-w-0 flex-1">
 			<!-- Rows -->
 			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-			<div class="relative cursor-crosshair" onclick={handleGridClick} tabindex="0" role="button">
-				<Tooltip.Provider delayDuration={200}>
+			<div class="relative" onclick={handleGridClick} tabindex="0" role="button">
+				<Tooltip.Provider delayDuration={100}>
 					<div class="flex flex-col gap-1.5">
 						{#each rows as row (row.region)}
 							<div class="relative h-8 overflow-hidden rounded-md">
@@ -92,7 +92,7 @@
 									{#snippet children({ payload })}
 										{#each row.blocks as block (block.startCost)}
 											<Tooltip.Trigger
-												class="absolute inset-y-0 cursor-crosshair"
+												class="absolute inset-y-0 "
 												style={getBlockStyle(block)}
 												tether={regionTether}
 												payload={block}

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -2,17 +2,35 @@
 	import { ScenarioToLabel } from '$lib/charts/baseChart';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { convertToLocaleString } from '$lib/number';
-	import type { Scenario, StrategiseResults } from '$lib/types/userState';
+	import type { Scenario, StrategiseResult, StrategiseResults } from '$lib/types/userState';
 	import { SvelteSet } from 'svelte/reactivity';
 	import type { Block } from '../schema';
 	import { createGridRows, getFillStyle } from '../utils';
+	import SelectedStrategy from './SelectedStrategy.svelte';
+	import { findClosestStrategiseResult } from '$lib/charts/strategyConfig';
 
 	interface Props {
 		strategiseResults: StrategiseResults;
 		minCost: number;
 		maxCost: number;
+		populations: Record<string, number>;
 	}
-	let { strategiseResults, minCost, maxCost }: Props = $props();
+	let { strategiseResults, minCost, maxCost, populations }: Props = $props();
+
+	let selectedStrategy = $state<StrategiseResult | null>(null);
+	let linePercent = $state<number | null>(null);
+
+	const handleGridClick = (event: MouseEvent) => {
+		const target = event.currentTarget as HTMLElement;
+		const rect = target.getBoundingClientRect();
+		const percent = (event.clientX - rect.left) / rect.width;
+		const clampedPercent = Math.max(0, Math.min(1, percent));
+		const cost = minCost + costRange * clampedPercent;
+		const strategy = findClosestStrategiseResult(strategiseResults, cost);
+		selectedStrategy = strategy;
+		const snappedPercent = costRange === 0 ? 0 : ((strategy.costThreshold - minCost) / costRange) * 100;
+		linePercent = snappedPercent;
+	};
 
 	let regionTether = Tooltip.createTether<Block>();
 	let costRange = $derived(maxCost - minCost);
@@ -20,9 +38,9 @@
 
 	let legendItems = $derived.by(() => {
 		const seen = new SvelteSet<Scenario>();
-		for (const result of strategiseResults) {
-			for (const intervention of result.interventions) {
-				seen.add(intervention.intervention);
+		for (const row of rows) {
+			for (const block of row.blocks) {
+				seen.add(block.intervention);
 			}
 		}
 		return seen;
@@ -46,7 +64,7 @@
 	});
 </script>
 
-<div class="mt-4 rounded-xl border bg-card p-6 shadow-sm">
+<div class="mt-4 rounded-md border bg-card p-6 shadow-sm">
 	<h3 class="mb-6 text-center text-lg font-semibold tracking-tight">Intervention Allocation by Cost of Strategy</h3>
 
 	<div class="flex items-end gap-3">
@@ -64,43 +82,51 @@
 		<!-- Grid + axis -->
 		<div class="min-w-0 flex-1">
 			<!-- Rows -->
-			<Tooltip.Provider delayDuration={100}>
-				<div class="flex flex-col gap-1.5">
-					{#each rows as row (row.region)}
-						<!-- overflow-hidden clips blocks to the rounded container -->
-						<div class="relative h-8 overflow-hidden rounded-md">
-							<Tooltip.Root tether={regionTether}>
-								{#snippet children({ payload })}
-									{#each row.blocks as block (block.startCost)}
-										<Tooltip.Trigger
-											class="absolute inset-y-0 "
-											style={getBlockStyle(block)}
-											tether={regionTether}
-											payload={block}
-										/>
-										<Tooltip.Content
-											class="rounded-md bg-background/90 text-foreground/90 "
-											arrowClasses="bg-background/90"
-										>
-											<div class="flex flex-col gap-1">
-												<span class="font-medium">
-													{ScenarioToLabel[payload!.intervention]}
-												</span>
-												<span class="text-muted-foreground">
-													${convertToLocaleString(payload!.startCost, 0)} - ${convertToLocaleString(
-														payload!.endCost,
-														0
-													)}
-												</span>
-											</div>
-										</Tooltip.Content>
-									{/each}
-								{/snippet}
-							</Tooltip.Root>
-						</div>
-					{/each}
-				</div>
-			</Tooltip.Provider>
+			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+			<div class="relative cursor-crosshair" onclick={handleGridClick} tabindex="0" role="button">
+				<Tooltip.Provider delayDuration={200}>
+					<div class="flex flex-col gap-1.5">
+						{#each rows as row (row.region)}
+							<div class="relative h-8 overflow-hidden rounded-md">
+								<Tooltip.Root tether={regionTether}>
+									{#snippet children({ payload })}
+										{#each row.blocks as block (block.startCost)}
+											<Tooltip.Trigger
+												class="absolute inset-y-0 cursor-crosshair"
+												style={getBlockStyle(block)}
+												tether={regionTether}
+												payload={block}
+											/>
+											<Tooltip.Content
+												class="rounded-md bg-background/90 text-foreground/90 "
+												arrowClasses="bg-background/90"
+											>
+												<div class="flex flex-col gap-1">
+													<span class="font-medium">
+														{ScenarioToLabel[payload!.intervention]}
+													</span>
+													<span class="text-muted-foreground">
+														${convertToLocaleString(payload!.startCost, 0)} - ${convertToLocaleString(
+															payload!.endCost,
+															0
+														)}
+													</span>
+												</div>
+											</Tooltip.Content>
+										{/each}
+									{/snippet}
+								</Tooltip.Root>
+							</div>
+						{/each}
+					</div>
+				</Tooltip.Provider>
+				{#if linePercent !== null}
+					<div
+						class="pointer-events-none absolute inset-y-0 -translate-x-1/2"
+						style="left: {linePercent}%; border-left: 2px dashed;"
+					></div>
+				{/if}
+			</div>
 
 			<!-- X-axis ticks -->
 			<div class="relative mt-1 h-7 border-t border-border/60">
@@ -126,13 +152,22 @@
 
 	<!-- Legend -->
 	<div
-		class="mt-5 flex flex-wrap justify-center gap-x-5 gap-y-2 rounded-lg border border-border/50 bg-muted/20 px-4 py-3"
+		class="mt-2 flex flex-wrap justify-center gap-x-5 gap-y-2 rounded-md border border-border/50 bg-muted/20 px-4 py-3"
 	>
 		{#each legendItems as scenario (scenario)}
 			<div class="flex items-center gap-2 text-sm">
-				<div class="h-3.5 w-5 rounded" style={getFillStyle(scenario)}></div>
+				<div class="h-3.5 w-5 rounded-xs" style={getFillStyle(scenario)}></div>
 				<span class="text-foreground/80">{ScenarioToLabel[scenario]}</span>
 			</div>
 		{/each}
 	</div>
+	<div class="mt-2 text-start text-xs text-muted-foreground/60">
+		Click anywhere on the grid to explore the optimal intervention strategy at the selected budget level
+	</div>
+
+	{#if selectedStrategy !== null}
+		<div class="mt-6 border-t pt-6">
+			<SelectedStrategy {selectedStrategy} {populations} />
+		</div>
+	{/if}
 </div>

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -106,10 +106,6 @@
 		return `left: ${left}%; width: ${width}%; ${style}`;
 	}
 
-	function getBlockId(region: string, block: Block): string {
-		return `${region}::${block.startCost}::${block.endCost}::${block.intervention}`;
-	}
-
 	const TICK_COUNT = 8;
 	let ticks = $derived.by(() => {
 		const result: number[] = [];
@@ -138,19 +134,13 @@
 		<!-- Grid + axis -->
 		<div class="min-w-0 flex-1">
 			<!-- Rows -->
-			<Tooltip.Provider delayDuration={200}>
+			<Tooltip.Provider delayDuration={100}>
 				<div class="flex flex-col gap-1.5">
 					{#each rows as row (row.region)}
 						<!-- overflow-hidden clips blocks to the rounded container -->
 						<div class="relative h-8 overflow-hidden rounded-md">
 							{#each row.blocks as block (block.startCost)}
-								{@const blockId = getBlockId(row.region, block)}
-								<Tooltip.Root
-									open={triggerId === blockId}
-									onOpenChange={(open) => {
-										triggerId = open ? blockId : triggerId === blockId ? null : triggerId;
-									}}
-								>
+								<Tooltip.Root>
 									<Tooltip.Trigger class="absolute inset-y-0 cursor-pointer" style={getBlockStyle(block)} />
 									<Tooltip.Content
 										class="rounded-md bg-background/90 text-foreground/90 shadow-lg"

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -20,8 +20,7 @@
 		region: string;
 		blocks: Block[];
 	}
-
-	let triggerId = $state<string | null>(null);
+	let regionTether = Tooltip.createTether();
 	let minCost = $derived(strategiseResults[0]?.costThreshold ?? 0);
 	let maxCost = $derived(strategiseResults[strategiseResults.length - 1]?.costThreshold ?? 0);
 	let costRange = $derived(maxCost - minCost);
@@ -139,11 +138,15 @@
 					{#each rows as row (row.region)}
 						<!-- overflow-hidden clips blocks to the rounded container -->
 						<div class="relative h-8 overflow-hidden rounded-md">
-							{#each row.blocks as block (block.startCost)}
-								<Tooltip.Root>
-									<Tooltip.Trigger class="absolute inset-y-0 cursor-pointer" style={getBlockStyle(block)} />
+							<Tooltip.Root tether={regionTether}>
+								{#each row.blocks as block (block.startCost)}
+									<Tooltip.Trigger
+										class="absolute inset-y-0 cursor-pointer"
+										style={getBlockStyle(block)}
+										tether={regionTether}
+									/>
 									<Tooltip.Content
-										class="rounded-md bg-background/90 text-foreground/90 shadow-lg"
+										class="rounded-md bg-background/90 text-foreground/90 "
 										arrowClasses="bg-background/90"
 									>
 										<div class="flex flex-col gap-1">
@@ -155,8 +158,8 @@
 											</span>
 										</div>
 									</Tooltip.Content>
-								</Tooltip.Root>
-							{/each}
+								{/each}
+							</Tooltip.Root>
 						</div>
 					{/each}
 				</div>

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -1,109 +1,40 @@
 <script lang="ts">
-	import { ScenarioToColor, ScenarioToLabel } from '$lib/charts/baseChart';
+	import { ScenarioToLabel } from '$lib/charts/baseChart';
 	import type { Scenario, StrategiseResults } from '$lib/types/userState';
 	import { convertToLocaleString } from '$lib/number';
 	import { SvelteSet } from 'svelte/reactivity';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import type { Block } from '../schema';
+	import { getFillStyle, createGridRows } from '../utils';
 
 	interface Props {
 		strategiseResults: StrategiseResults;
+		minCost: number;
+		maxCost: number;
 	}
-	let { strategiseResults }: Props = $props();
+	let { strategiseResults, minCost, maxCost }: Props = $props();
 
-	interface Block {
-		intervention: Scenario;
-		startCost: number;
-		endCost: number;
-	}
-
-	interface RegionRow {
-		region: string;
-		blocks: Block[];
-	}
 	let regionTether = Tooltip.createTether();
-	let minCost = $derived(strategiseResults[0]?.costThreshold ?? 0);
-	let maxCost = $derived(strategiseResults[strategiseResults.length - 1]?.costThreshold ?? 0);
 	let costRange = $derived(maxCost - minCost);
-
-	let regions = $derived.by(() => {
-		if (strategiseResults.length === 0) return [];
-		return strategiseResults[0].interventions.map((i) => i.region);
-	});
-
-	let rows = $derived.by((): RegionRow[] => {
-		return regions.map((region) => {
-			const blocks: Block[] = [];
-			let currentIntervention: Scenario | null = null;
-			let blockStart = 0;
-
-			for (let i = 0; i < strategiseResults.length; i++) {
-				const result = strategiseResults[i];
-				const intervention = result.interventions.find((inv) => inv.region === region);
-				if (!intervention) continue;
-
-				if (intervention.intervention !== currentIntervention) {
-					if (currentIntervention !== null) {
-						blocks.push({
-							intervention: currentIntervention,
-							startCost: blockStart,
-							endCost: result.costThreshold
-						});
-					}
-					currentIntervention = intervention.intervention;
-					blockStart = result.costThreshold;
-				}
-			}
-
-			if (currentIntervention !== null) {
-				blocks.push({
-					intervention: currentIntervention,
-					startCost: blockStart,
-					endCost: maxCost
-				});
-			}
-
-			return { region, blocks };
-		});
-	});
+	let rows = $derived(createGridRows(strategiseResults, maxCost));
 
 	let legendItems = $derived.by(() => {
 		const seen = new SvelteSet<Scenario>();
 		for (const result of strategiseResults) {
-			for (const inv of result.interventions) {
-				seen.add(inv.intervention);
+			for (const intervention of result.interventions) {
+				seen.add(intervention.intervention);
 			}
 		}
 		return seen;
 	});
 
-	function getWidthPercent(block: Block): number {
-		if (costRange === 0) return 100;
-		return ((block.endCost - block.startCost) / costRange) * 100;
-	}
-
-	function getLeftPercent(block: Block): number {
-		if (costRange === 0) return 0;
-		return ((block.startCost - minCost) / costRange) * 100;
-	}
-
-	const LSM_STRIPE =
-		'repeating-linear-gradient(45deg, transparent, transparent 4px, var(--background) 7px, var(--background) 8px)';
-
-	function getFillStyle(scenario: Scenario): string {
-		const color = ScenarioToColor[scenario];
-		let style = `background-color: ${color};`;
-		if (scenario.includes('lsm')) {
-			style += ` background-image: ${LSM_STRIPE};`;
-		}
-		return style;
-	}
-
-	function getBlockStyle(block: Block): string {
-		const left = getLeftPercent(block);
-		const width = getWidthPercent(block);
-		const style = getFillStyle(block.intervention);
-		return `left: ${left}%; width: ${width}%; ${style}`;
-	}
+	const getBlockStyle = (block: Block): string => {
+		if (costRange === 0) return '';
+		const fillStyle = getFillStyle(block.intervention);
+		const left = ((block.startCost - minCost) / costRange) * 100;
+		const width = ((block.endCost - block.startCost) / costRange) * 100;
+		return `left: ${left}%; width: ${width}%; ${fillStyle}`;
+	};
 
 	const TICK_COUNT = 8;
 	let ticks = $derived.by(() => {
@@ -120,7 +51,7 @@
 
 	<div class="flex items-end gap-3">
 		<!-- Region labels -->
-		<div class="flex shrink-0 flex-col gap-2">
+		<div class="flex shrink-0 flex-col gap-1.5">
 			{#each rows as row (row.region)}
 				<div class="flex h-8 items-center justify-end text-right text-sm font-medium text-muted-foreground">
 					{row.region}
@@ -140,11 +71,7 @@
 						<div class="relative h-8 overflow-hidden rounded-md">
 							<Tooltip.Root tether={regionTether}>
 								{#each row.blocks as block (block.startCost)}
-									<Tooltip.Trigger
-										class="absolute inset-y-0 cursor-pointer"
-										style={getBlockStyle(block)}
-										tether={regionTether}
-									/>
+									<Tooltip.Trigger class="absolute inset-y-0 " style={getBlockStyle(block)} tether={regionTether} />
 									<Tooltip.Content
 										class="rounded-md bg-background/90 text-foreground/90 "
 										arrowClasses="bg-background/90"

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -11,16 +11,16 @@
 	interface Props {
 		strategiseResults: StrategiseResults;
 		minCost: number;
-		maxCost: number;
+		budget: number;
 		populations: Record<string, number>;
 		selectedStrategy: StrategiseResult;
 		selectStrategy: (strategy: StrategiseResult) => void;
 	}
-	let { strategiseResults, minCost, maxCost, populations, selectedStrategy, selectStrategy }: Props = $props();
+	let { strategiseResults, minCost, budget, populations, selectedStrategy, selectStrategy }: Props = $props();
 
 	let regionTether = Tooltip.createTether<Block>();
-	let costRange = $derived(maxCost - minCost);
-	let rows = $derived(createGridRows(strategiseResults, maxCost));
+	let costRange = $derived(budget - minCost);
+	let rows = $derived(createGridRows(strategiseResults, budget));
 	let selectedPercent = $derived<number>(calculateRangePercent(selectedStrategy.costThreshold - minCost, costRange));
 	let ticks = $derived(getGridTicks(minCost, costRange));
 	let legendItems = $derived(getGridLegendItems(rows));
@@ -64,7 +64,14 @@
 		<!-- Grid + axis -->
 		<div class="min-w-0 flex-1">
 			<!-- Rows -->
-			<div class="relative" onclick={handleGridClick} role="radiogroup" tabindex={0} onkeydown={() => {}}>
+			<div
+				class="relative"
+				onclick={handleGridClick}
+				role="button"
+				tabindex={0}
+				onkeydown={() => {}}
+				aria-label="click to select strategy based on budget"
+			>
 				<Tooltip.Provider delayDuration={100}>
 					<div class="flex flex-col gap-1.5">
 						{#each rows as row (row.region)}
@@ -78,23 +85,23 @@
 												tether={regionTether}
 												payload={block}
 											/>
-											<Tooltip.Content
-												class="rounded-md bg-background/90 text-foreground/90 "
-												arrowClasses="bg-background/90"
-											>
-												<div class="flex flex-col gap-1">
-													<span class="font-medium">
-														{ScenarioToLabel[payload!.intervention]}
-													</span>
-													<span class="text-muted-foreground">
-														${convertToLocaleString(payload!.startCost, 0)} - ${convertToLocaleString(
-															payload!.endCost,
-															0
-														)}
-													</span>
-												</div>
-											</Tooltip.Content>
 										{/each}
+										<Tooltip.Content
+											class="rounded-md bg-background/90 text-foreground/90 "
+											arrowClasses="bg-background/90"
+										>
+											<div class="flex flex-col gap-1">
+												<span class="font-medium">
+													{ScenarioToLabel[payload!.intervention]}
+												</span>
+												<span class="text-muted-foreground">
+													${convertToLocaleString(payload!.startCost, 0)} - ${convertToLocaleString(
+														payload!.endCost,
+														0
+													)}
+												</span>
+											</div>
+										</Tooltip.Content>
 									{/snippet}
 								</Tooltip.Root>
 							</div>

--- a/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/InterventionGrid.svelte
@@ -1,24 +1,29 @@
 <script lang="ts">
 	import { ScenarioToLabel } from '$lib/charts/baseChart';
-	import * as Tooltip from '$lib/components/ui/tooltip';
-	import { convertToLocaleString } from '$lib/number';
-	import type { Scenario, StrategiseResult, StrategiseResults } from '$lib/types/userState';
-	import { SvelteSet } from 'svelte/reactivity';
-	import type { Block } from '../schema';
-	import { createGridRows, getFillStyle } from '../utils';
-	import SelectedStrategy from './SelectedStrategy.svelte';
 	import { findClosestStrategiseResult } from '$lib/charts/strategyConfig';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { calculateRangePercent, convertToLocaleString } from '$lib/number';
+	import type { StrategiseResult, StrategiseResults } from '$lib/types/userState';
+	import type { Block } from '../schema';
+	import { createGridRows, getFillStyle, getGridLegendItems, getGridTicks } from '../utils';
+	import SelectedStrategy from './SelectedStrategy.svelte';
 
 	interface Props {
 		strategiseResults: StrategiseResults;
 		minCost: number;
 		maxCost: number;
 		populations: Record<string, number>;
+		selectedStrategy: StrategiseResult;
+		selectStrategy: (strategy: StrategiseResult) => void;
 	}
-	let { strategiseResults, minCost, maxCost, populations }: Props = $props();
+	let { strategiseResults, minCost, maxCost, populations, selectedStrategy, selectStrategy }: Props = $props();
 
-	let selectedStrategy = $state<StrategiseResult | null>(null);
-	let linePercent = $state<number | null>(null);
+	let regionTether = Tooltip.createTether<Block>();
+	let costRange = $derived(maxCost - minCost);
+	let rows = $derived(createGridRows(strategiseResults, maxCost));
+	let selectedPercent = $derived<number>(calculateRangePercent(selectedStrategy.costThreshold - minCost, costRange));
+	let ticks = $derived(getGridTicks(minCost, costRange));
+	let legendItems = $derived(getGridLegendItems(rows));
 
 	const handleGridClick = (event: MouseEvent) => {
 		const target = event.currentTarget as HTMLElement;
@@ -27,41 +32,18 @@
 		const clampedPercent = Math.max(0, Math.min(1, percent));
 		const cost = minCost + costRange * clampedPercent;
 		const strategy = findClosestStrategiseResult(strategiseResults, cost);
-		selectedStrategy = strategy;
-		const snappedPercent = costRange === 0 ? 0 : ((strategy.costThreshold - minCost) / costRange) * 100;
-		linePercent = snappedPercent;
+		selectStrategy(strategy);
+		const snappedPercent = calculateRangePercent(strategy.costThreshold - minCost, costRange);
+		selectedPercent = snappedPercent;
 	};
-
-	let regionTether = Tooltip.createTether<Block>();
-	let costRange = $derived(maxCost - minCost);
-	let rows = $derived(createGridRows(strategiseResults, maxCost));
-
-	let legendItems = $derived.by(() => {
-		const seen = new SvelteSet<Scenario>();
-		for (const row of rows) {
-			for (const block of row.blocks) {
-				seen.add(block.intervention);
-			}
-		}
-		return seen;
-	});
 
 	const getBlockStyle = (block: Block): string => {
 		if (costRange === 0) return '';
 		const fillStyle = getFillStyle(block.intervention);
-		const left = ((block.startCost - minCost) / costRange) * 100;
-		const width = ((block.endCost - block.startCost) / costRange) * 100;
+		const left = calculateRangePercent(block.startCost - minCost, costRange);
+		const width = calculateRangePercent(block.endCost - block.startCost, costRange);
 		return `left: ${left}%; width: ${width}%; ${fillStyle}`;
 	};
-
-	const TICK_COUNT = 8;
-	let ticks = $derived.by(() => {
-		const result: number[] = [];
-		for (let i = 0; i <= TICK_COUNT; i++) {
-			result.push(minCost + (costRange * i) / TICK_COUNT);
-		}
-		return result;
-	});
 </script>
 
 <div class="mt-4 rounded-md border bg-card p-6 shadow-sm">
@@ -82,8 +64,7 @@
 		<!-- Grid + axis -->
 		<div class="min-w-0 flex-1">
 			<!-- Rows -->
-			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-			<div class="relative" onclick={handleGridClick} tabindex="0" role="button">
+			<div class="relative" onclick={handleGridClick} role="radiogroup" tabindex={0} onkeydown={() => {}}>
 				<Tooltip.Provider delayDuration={100}>
 					<div class="flex flex-col gap-1.5">
 						{#each rows as row (row.region)}
@@ -120,18 +101,19 @@
 						{/each}
 					</div>
 				</Tooltip.Provider>
-				{#if linePercent !== null}
-					<div
-						class="pointer-events-none absolute inset-y-0 -translate-x-1/2"
-						style="left: {linePercent}%; border-left: 2px dashed;"
-					></div>
+				{#if selectedPercent !== null}
+					<div class="pointer-events-none absolute inset-y-0 -translate-x-1/2" style="left: {selectedPercent}%;">
+						<div class="h-full border border-dashed border-foreground"></div>
+
+						<span class="absolute -top-2 -translate-1/2 text-xs font-medium text-nowrap"> Explored budget </span>
+					</div>
 				{/if}
 			</div>
 
 			<!-- X-axis ticks -->
 			<div class="relative mt-1 h-7 border-t border-border/60">
 				{#each ticks as tick, i (tick)}
-					{@const percentage = costRange === 0 ? 0 : ((tick - minCost) / costRange) * 100}
+					{@const percentage = calculateRangePercent(tick - minCost, costRange)}
 					<div
 						class="absolute top-1.5 text-xs text-muted-foreground"
 						style="left: {percentage}%; transform: translateX({i === ticks.length - 1
@@ -149,10 +131,13 @@
 
 	<!-- X-axis label -->
 	<div class="mt-1 text-center text-sm text-muted-foreground">Total cost ($USD)</div>
+	<div class="text-start text-xs text-muted-foreground/60">
+		Click anywhere on the grid to explore the optimal intervention strategy at the selected budget level
+	</div>
 
 	<!-- Legend -->
 	<div
-		class="mt-2 flex flex-wrap justify-center gap-x-5 gap-y-2 rounded-md border border-border/50 bg-muted/20 px-4 py-3"
+		class="mt-1 flex flex-wrap justify-center gap-x-5 gap-y-2 rounded-md border border-border/50 bg-muted/20 px-4 py-3"
 	>
 		{#each legendItems as scenario (scenario)}
 			<div class="flex items-center gap-2 text-sm">
@@ -161,10 +146,6 @@
 			</div>
 		{/each}
 	</div>
-	<div class="mt-2 text-start text-xs text-muted-foreground/60">
-		Click anywhere on the grid to explore the optimal intervention strategy at the selected budget level
-	</div>
-
 	{#if selectedStrategy !== null}
 		<div class="mt-6 border-t pt-6">
 			<SelectedStrategy {selectedStrategy} {populations} />

--- a/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
@@ -2,7 +2,9 @@
 	import { createHighchart, getChartTheme } from '$lib/charts/baseChart';
 	import { getStrategyConfig } from '$lib/charts/strategyConfig';
 	import Loader from '$lib/components/Loader.svelte';
+	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import type { StrategiseResult, StrategiseResults } from '$lib/types/userState';
+	import InterventionGrid from './InterventionGrid.svelte';
 	import SelectedStrategy from './SelectedStrategy.svelte';
 
 	interface Props {
@@ -16,10 +18,21 @@
 </script>
 
 <div>
-	<div {@attach createHighchart(config, () => (isChartLoading = false))} class={getChartTheme()}></div>
-	{#if isChartLoading}
-		<Loader />
-	{:else}
-		<SelectedStrategy {selectedStrategy} {populations} />
-	{/if}
+	<Tabs.Root value="chart">
+		<Tabs.List>
+			<Tabs.Trigger value="chart">Cases Averted Chart</Tabs.Trigger>
+			<Tabs.Trigger value="grid">Allocation Grid</Tabs.Trigger>
+		</Tabs.List>
+		<Tabs.Content value="chart">
+			<div {@attach createHighchart(config, () => (isChartLoading = false))} class={getChartTheme()}></div>
+			{#if isChartLoading}
+				<Loader />
+			{:else}
+				<SelectedStrategy {selectedStrategy} {populations} />
+			{/if}
+		</Tabs.Content>
+		<Tabs.Content value="grid">
+			<InterventionGrid {strategiseResults} />
+		</Tabs.Content>
+	</Tabs.Root>
 </div>

--- a/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
@@ -34,7 +34,7 @@
 			{/if}
 		</Tabs.Content>
 		<Tabs.Content value="grid">
-			<InterventionGrid {strategiseResults} {minCost} {maxCost} />
+			<InterventionGrid {strategiseResults} {minCost} {maxCost} {populations} />
 		</Tabs.Content>
 	</Tabs.Root>
 </div>

--- a/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
@@ -10,8 +10,10 @@
 	interface Props {
 		strategiseResults: StrategiseResults;
 		populations: Record<string, number>;
+		minCost: number;
+		maxCost: number;
 	}
-	let { strategiseResults, populations }: Props = $props();
+	let { strategiseResults, populations, minCost, maxCost }: Props = $props();
 	let isChartLoading = $state(true);
 	let selectedStrategy = $state<StrategiseResult>(strategiseResults[strategiseResults.length - 1]);
 	let config = $derived(getStrategyConfig(strategiseResults, (strategy) => (selectedStrategy = strategy)));
@@ -32,7 +34,7 @@
 			{/if}
 		</Tabs.Content>
 		<Tabs.Content value="grid">
-			<InterventionGrid {strategiseResults} />
+			<InterventionGrid {strategiseResults} {minCost} {maxCost} />
 		</Tabs.Content>
 	</Tabs.Root>
 </div>

--- a/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { createHighchart, getChartTheme } from '$lib/charts/baseChart';
-	import { getStrategyConfig } from '$lib/charts/strategyConfig';
+	import { addBudgetPlotLine, getStrategyConfig } from '$lib/charts/strategyConfig';
 	import Loader from '$lib/components/Loader.svelte';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import type { StrategiseResult, StrategiseResults } from '$lib/types/userState';
@@ -15,8 +15,18 @@
 	}
 	let { strategiseResults, populations, minCost, maxCost }: Props = $props();
 	let isChartLoading = $state(true);
+	let strategiseChart = $state<Highcharts.Chart | null>(null);
 	let selectedStrategy = $state<StrategiseResult>(strategiseResults[strategiseResults.length - 1]);
-	let config = $derived(getStrategyConfig(strategiseResults, (strategy) => (selectedStrategy = strategy)));
+	const selectStrategy = (strategy: StrategiseResult) => {
+		selectedStrategy = strategy;
+	};
+	let config = $derived(getStrategyConfig(strategiseResults, selectStrategy));
+
+	const updateStrategyAndPlotLine = (strategy: StrategiseResult) => {
+		selectStrategy(strategy);
+		if (!strategiseChart) return;
+		addBudgetPlotLine(strategiseChart, strategy.costThreshold);
+	};
 </script>
 
 <div>
@@ -26,7 +36,13 @@
 			<Tabs.Trigger value="grid">Allocation Grid</Tabs.Trigger>
 		</Tabs.List>
 		<Tabs.Content value="chart">
-			<div {@attach createHighchart(config, () => (isChartLoading = false))} class={getChartTheme()}></div>
+			<div
+				{@attach createHighchart(config, (chart) => {
+					isChartLoading = false;
+					strategiseChart = chart;
+				})}
+				class={getChartTheme()}
+			></div>
 			{#if isChartLoading}
 				<Loader />
 			{:else}
@@ -34,7 +50,14 @@
 			{/if}
 		</Tabs.Content>
 		<Tabs.Content value="grid">
-			<InterventionGrid {strategiseResults} {minCost} {maxCost} {populations} />
+			<InterventionGrid
+				{strategiseResults}
+				{minCost}
+				{maxCost}
+				{populations}
+				{selectedStrategy}
+				selectStrategy={updateStrategyAndPlotLine}
+			/>
 		</Tabs.Content>
 	</Tabs.Root>
 </div>

--- a/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
+++ b/client/src/routes/projects/[project]/strategise/_components/StrategiseResults.svelte
@@ -11,9 +11,9 @@
 		strategiseResults: StrategiseResults;
 		populations: Record<string, number>;
 		minCost: number;
-		maxCost: number;
+		budget: number;
 	}
-	let { strategiseResults, populations, minCost, maxCost }: Props = $props();
+	let { strategiseResults, populations, minCost, budget }: Props = $props();
 	let isChartLoading = $state(true);
 	let strategiseChart = $state<Highcharts.Chart | null>(null);
 	let selectedStrategy = $state<StrategiseResult>(strategiseResults[strategiseResults.length - 1]);
@@ -53,7 +53,7 @@
 			<InterventionGrid
 				{strategiseResults}
 				{minCost}
-				{maxCost}
+				{budget}
 				{populations}
 				{selectedStrategy}
 				selectStrategy={updateStrategyAndPlotLine}

--- a/client/src/routes/projects/[project]/strategise/schema.ts
+++ b/client/src/routes/projects/[project]/strategise/schema.ts
@@ -66,3 +66,14 @@ export interface CompareStrategiseRegions {
 export type StrategiseResultIntervention<K extends MetricKey> = StrategiseIntervention<K> & {
 	region: string;
 };
+
+export interface Block {
+	intervention: Scenario;
+	startCost: number;
+	endCost: number;
+}
+
+export interface RegionRow {
+	region: string;
+	blocks: Block[];
+}

--- a/client/src/routes/projects/[project]/strategise/utils.ts
+++ b/client/src/routes/projects/[project]/strategise/utils.ts
@@ -18,11 +18,14 @@ import type {
 } from '$lib/types/userState';
 import { equalTo, lessEq, solve, type Constraint, type Model } from 'yalps';
 import type {
+	Block,
 	CompareStrategiseRegions,
 	MetricKey,
+	RegionRow,
 	StrategiseRegionByMetric,
 	StrategiseResultIntervention
 } from './schema';
+import { ScenarioToColor } from '$lib/charts/baseChart';
 
 const mapTotalsToInterventions = (
 	totals: ReturnType<typeof getTotalCasesAndCostsPerScenario>
@@ -373,3 +376,83 @@ export const constructRegionalMetrics = (strategy: StrategiseResult, populations
 			];
 		})
 	);
+
+/*** Intervention grid utilities ***/
+const LSM_STRIPE =
+	'repeating-linear-gradient(45deg, transparent, transparent 4px, var(--background) 7px, var(--background) 8px)';
+export const getFillStyle = (scenario: Scenario): string => {
+	const color = ScenarioToColor[scenario];
+	let style = `background-color: ${color};`;
+	if (scenario.includes('lsm')) {
+		style += ` background-image: ${LSM_STRIPE};`;
+	}
+	return style;
+};
+
+type RegionState = {
+	currentIntervention: Scenario | null;
+	blockStart: number;
+	blocks: Block[];
+};
+
+const pushClosedBlock = (state: RegionState, endCost: number) => {
+	if (state.currentIntervention === null) return;
+
+	state.blocks.push({
+		intervention: state.currentIntervention,
+		startCost: state.blockStart,
+		endCost
+	});
+};
+
+const updateRegionState = (state: RegionState, intervention: Scenario, threshold: number) => {
+	if (intervention === state.currentIntervention) return;
+
+	pushClosedBlock(state, threshold);
+	state.currentIntervention = intervention;
+	state.blockStart = threshold;
+};
+
+const buildRegionStates = (
+	strategiseResults: StrategiseResults,
+	allowedRegions: Set<string>
+): Map<string, RegionState> => {
+	const states = new Map<string, RegionState>();
+
+	for (const result of strategiseResults) {
+		const threshold = result.costThreshold;
+
+		for (const { region, intervention } of result.interventions) {
+			if (!allowedRegions.has(region)) continue;
+
+			let state = states.get(region);
+			if (!state) {
+				state = { currentIntervention: null, blockStart: 0, blocks: [] };
+				states.set(region, state);
+			}
+
+			updateRegionState(state, intervention, threshold);
+		}
+	}
+
+	return states;
+};
+
+const finalizeRegionRows = (regions: string[], states: Map<string, RegionState>, maxCost: number): RegionRow[] => {
+	return regions.map((region) => {
+		const state = states.get(region);
+		if (!state) return { region, blocks: [] };
+
+		pushClosedBlock(state, maxCost);
+		return { region, blocks: state.blocks };
+	});
+};
+
+export const createGridRows = (strategiseResults: StrategiseResults, maxCost: number): RegionRow[] => {
+	if (strategiseResults.length === 0) return [];
+
+	const regions = strategiseResults[0].interventions.map((i) => i.region);
+
+	const states = buildRegionStates(strategiseResults, new Set(regions));
+	return finalizeRegionRows(regions, states, maxCost);
+};

--- a/client/src/routes/projects/[project]/strategise/utils.ts
+++ b/client/src/routes/projects/[project]/strategise/utils.ts
@@ -1,3 +1,4 @@
+import { ScenarioToColor } from '$lib/charts/baseChart';
 import type { FormValue } from '$lib/components/dynamic-region-form/types';
 import { createLinearSpace } from '$lib/number';
 import { combineCostsAndCasesAverted, getTotalCostsPerScenario } from '$lib/process-results/costs';
@@ -25,8 +26,6 @@ import type {
 	StrategiseRegionByMetric,
 	StrategiseResultIntervention
 } from './schema';
-import { ScenarioToColor } from '$lib/charts/baseChart';
-import { SvelteSet } from 'svelte/reactivity';
 
 const mapTotalsToInterventions = (
 	totals: ReturnType<typeof getTotalCasesAndCostsPerScenario>
@@ -468,7 +467,7 @@ export const getGridTicks = (minCost: number, costRange: number) => {
 };
 
 export const getGridLegendItems = (rows: RegionRow[]) => {
-	const uniqueScenarios = new SvelteSet<Scenario>();
+	const uniqueScenarios = new Set<Scenario>();
 	for (const row of rows) {
 		for (const block of row.blocks) {
 			uniqueScenarios.add(block.intervention);

--- a/client/src/routes/projects/[project]/strategise/utils.ts
+++ b/client/src/routes/projects/[project]/strategise/utils.ts
@@ -26,6 +26,7 @@ import type {
 	StrategiseResultIntervention
 } from './schema';
 import { ScenarioToColor } from '$lib/charts/baseChart';
+import { SvelteSet } from 'svelte/reactivity';
 
 const mapTotalsToInterventions = (
 	totals: ReturnType<typeof getTotalCasesAndCostsPerScenario>
@@ -455,4 +456,23 @@ export const createGridRows = (strategiseResults: StrategiseResults, maxCost: nu
 
 	const states = buildRegionStates(strategiseResults, new Set(regions));
 	return finalizeRegionRows(regions, states, maxCost);
+};
+
+export const getGridTicks = (minCost: number, costRange: number) => {
+	const TICK_COUNT = 8;
+	const result: number[] = [];
+	for (let i = 0; i <= TICK_COUNT; i++) {
+		result.push(minCost + (costRange * i) / TICK_COUNT);
+	}
+	return result;
+};
+
+export const getGridLegendItems = (rows: RegionRow[]) => {
+	const uniqueScenarios = new SvelteSet<Scenario>();
+	for (const row of rows) {
+		for (const block of row.blocks) {
+			uniqueScenarios.add(block.intervention);
+		}
+	}
+	return uniqueScenarios;
 };

--- a/client/src/tests/lib/number.spec.ts
+++ b/client/src/tests/lib/number.spec.ts
@@ -1,4 +1,10 @@
-import { convertToLocaleString, createLinearSpace, ROUNDING_METHODS, roundNumber } from '$lib/number';
+import {
+	calculateRangePercent,
+	convertToLocaleString,
+	createLinearSpace,
+	ROUNDING_METHODS,
+	roundNumber
+} from '$lib/number';
 
 describe('roundNumber', () => {
 	it('should round number with default 2 decimal places', () => {
@@ -134,5 +140,17 @@ describe('ROUNDING_METHODS', () => {
 		expect(ROUNDING_METHODS.ceil).toBe(Math.ceil);
 		expect(ROUNDING_METHODS.floor).toBe(Math.floor);
 		expect(ROUNDING_METHODS.round).toBe(Math.round);
+	});
+});
+
+describe('calculateRangePercent', () => {
+	it('should calculate percentage correctly', () => {
+		expect(calculateRangePercent(50, 200)).toBe(25);
+		expect(calculateRangePercent(0, 100)).toBe(0);
+		expect(calculateRangePercent(100, 100)).toBe(100);
+	});
+
+	it('should handle division by zero', () => {
+		expect(calculateRangePercent(50, 0)).toBe(0);
 	});
 });

--- a/client/src/tests/routes/projects/[project]/strategise/_components/InterventionGrid.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/strategise/_components/InterventionGrid.svelte.spec.ts
@@ -26,11 +26,15 @@ const strategiseResults: StrategiseResults = [
 		]
 	}
 ];
-
+const selectedStrategy = strategiseResults[1]; // Select the strategy with costThreshold 200
+const populations = {
+	'Region A': 1000,
+	'Region B': 2000
+};
 describe('InterventionGrid', () => {
 	it('should render the heading', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300 }
+			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
 		await expect
@@ -40,38 +44,38 @@ describe('InterventionGrid', () => {
 
 	it('should render region labels', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300 }
+			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
-		await expect.element(screen.getByText('Region A')).toBeVisible();
-		await expect.element(screen.getByText('Region B')).toBeVisible();
+		await expect.element(screen.getByText('Region A').first()).toBeVisible();
+		await expect.element(screen.getByText('Region B').first()).toBeVisible();
 	});
 
 	it('should render legend items for each unique intervention', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300 }
+			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
-		await expect.element(screen.getByText(ScenarioToLabel['irs_only'])).toBeVisible();
-		await expect.element(screen.getByText(ScenarioToLabel['lsm_only'])).toBeVisible();
-		await expect.element(screen.getByText(ScenarioToLabel['py_only_only'])).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['irs_only']).first()).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['lsm_only']).first()).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['py_only_only']).first()).toBeVisible();
 	});
 
 	it('should render x-axis label', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300 }
+			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
-		await expect.element(screen.getByText('Total cost ($USD)')).toBeVisible();
+		await expect.element(screen.getByText('Total cost ($USD)').first()).toBeVisible();
 	});
 
 	it('should render x-axis tick for minCost and maxCost', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300 }
+			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
-		await expect.element(screen.getByText('$100')).toBeVisible();
-		await expect.element(screen.getByText('$300')).toBeVisible();
+		await expect.element(screen.getByText('$100').first()).toBeVisible();
+		await expect.element(screen.getByText('$300').first()).toBeVisible();
 	});
 
 	it('should render with a single region', async () => {
@@ -87,11 +91,36 @@ describe('InterventionGrid', () => {
 		];
 
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults: singleRegionResults, minCost: 0, maxCost: 500 }
+			props: {
+				strategiseResults: singleRegionResults,
+				minCost: 0,
+				maxCost: 500,
+				selectedStrategy,
+				selectStrategy: vi.fn(),
+				populations
+			}
 		} as any);
 
-		await expect.element(screen.getByText('Region A')).toBeVisible();
-		await expect.element(screen.getByText(ScenarioToLabel['no_intervention'])).toBeVisible();
-		await expect.element(screen.getByText(ScenarioToLabel['irs_only'])).toBeVisible();
+		await expect.element(screen.getByText('Region A').first()).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['no_intervention']).first()).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['irs_only']).first()).toBeVisible();
+	});
+
+	it('should show explored budget line and strategy summary after clicking the intervention grid', async () => {
+		const selectStrategy = vi.fn();
+		const screen = render(InterventionGrid, {
+			strategiseResults,
+			minCost: 0,
+			maxCost: 1000,
+			populations,
+			selectedStrategy,
+			selectStrategy
+		} as any);
+
+		await screen.getByRole('radiogroup').click();
+
+		await expect.element(screen.getByText('Explored budget')).toBeVisible();
+		await expect.element(screen.getByRole('heading', { name: 'Optimal strategy for selected budget' })).toBeVisible();
+		expect(selectStrategy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/client/src/tests/routes/projects/[project]/strategise/_components/InterventionGrid.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/strategise/_components/InterventionGrid.svelte.spec.ts
@@ -1,0 +1,97 @@
+import { ScenarioToLabel } from '$lib/charts/baseChart';
+import type { StrategiseResults } from '$lib/types/userState';
+import InterventionGrid from '$routes/projects/[project]/strategise/_components/InterventionGrid.svelte';
+import { render } from 'vitest-browser-svelte';
+
+const strategiseResults: StrategiseResults = [
+	{
+		costThreshold: 100,
+		interventions: [
+			{ region: 'Region A', intervention: 'irs_only', cost: 100, casesAverted: 50 },
+			{ region: 'Region B', intervention: 'lsm_only', cost: 100, casesAverted: 80 }
+		]
+	},
+	{
+		costThreshold: 200,
+		interventions: [
+			{ region: 'Region A', intervention: 'irs_only', cost: 100, casesAverted: 50 },
+			{ region: 'Region B', intervention: 'py_only_only', cost: 200, casesAverted: 120 }
+		]
+	},
+	{
+		costThreshold: 300,
+		interventions: [
+			{ region: 'Region A', intervention: 'lsm_only', cost: 200, casesAverted: 90 },
+			{ region: 'Region B', intervention: 'py_only_only', cost: 200, casesAverted: 120 }
+		]
+	}
+];
+
+describe('InterventionGrid', () => {
+	it('should render the heading', async () => {
+		const screen = render(InterventionGrid, {
+			props: { strategiseResults, minCost: 100, maxCost: 300 }
+		} as any);
+
+		await expect
+			.element(screen.getByRole('heading', { name: 'Intervention Allocation by Cost of Strategy' }))
+			.toBeVisible();
+	});
+
+	it('should render region labels', async () => {
+		const screen = render(InterventionGrid, {
+			props: { strategiseResults, minCost: 100, maxCost: 300 }
+		} as any);
+
+		await expect.element(screen.getByText('Region A')).toBeVisible();
+		await expect.element(screen.getByText('Region B')).toBeVisible();
+	});
+
+	it('should render legend items for each unique intervention', async () => {
+		const screen = render(InterventionGrid, {
+			props: { strategiseResults, minCost: 100, maxCost: 300 }
+		} as any);
+
+		await expect.element(screen.getByText(ScenarioToLabel['irs_only'])).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['lsm_only'])).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['py_only_only'])).toBeVisible();
+	});
+
+	it('should render x-axis label', async () => {
+		const screen = render(InterventionGrid, {
+			props: { strategiseResults, minCost: 100, maxCost: 300 }
+		} as any);
+
+		await expect.element(screen.getByText('Total cost ($USD)')).toBeVisible();
+	});
+
+	it('should render x-axis tick for minCost and maxCost', async () => {
+		const screen = render(InterventionGrid, {
+			props: { strategiseResults, minCost: 100, maxCost: 300 }
+		} as any);
+
+		await expect.element(screen.getByText('$100')).toBeVisible();
+		await expect.element(screen.getByText('$300')).toBeVisible();
+	});
+
+	it('should render with a single region', async () => {
+		const singleRegionResults: StrategiseResults = [
+			{
+				costThreshold: 0,
+				interventions: [{ region: 'Region A', intervention: 'no_intervention', cost: 0, casesAverted: 0 }]
+			},
+			{
+				costThreshold: 500,
+				interventions: [{ region: 'Region A', intervention: 'irs_only', cost: 500, casesAverted: 50 }]
+			}
+		];
+
+		const screen = render(InterventionGrid, {
+			props: { strategiseResults: singleRegionResults, minCost: 0, maxCost: 500 }
+		} as any);
+
+		await expect.element(screen.getByText('Region A')).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['no_intervention'])).toBeVisible();
+		await expect.element(screen.getByText(ScenarioToLabel['irs_only'])).toBeVisible();
+	});
+});

--- a/client/src/tests/routes/projects/[project]/strategise/_components/InterventionGrid.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/strategise/_components/InterventionGrid.svelte.spec.ts
@@ -34,7 +34,7 @@ const populations = {
 describe('InterventionGrid', () => {
 	it('should render the heading', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
+			props: { strategiseResults, minCost: 100, budget: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
 		await expect
@@ -44,7 +44,7 @@ describe('InterventionGrid', () => {
 
 	it('should render region labels', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
+			props: { strategiseResults, minCost: 100, budget: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
 		await expect.element(screen.getByText('Region A').first()).toBeVisible();
@@ -53,7 +53,7 @@ describe('InterventionGrid', () => {
 
 	it('should render legend items for each unique intervention', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
+			props: { strategiseResults, minCost: 100, budget: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
 		await expect.element(screen.getByText(ScenarioToLabel['irs_only']).first()).toBeVisible();
@@ -63,15 +63,15 @@ describe('InterventionGrid', () => {
 
 	it('should render x-axis label', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
+			props: { strategiseResults, minCost: 100, budget: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
 		await expect.element(screen.getByText('Total cost ($USD)').first()).toBeVisible();
 	});
 
-	it('should render x-axis tick for minCost and maxCost', async () => {
+	it('should render x-axis tick for minCost and budget', async () => {
 		const screen = render(InterventionGrid, {
-			props: { strategiseResults, minCost: 100, maxCost: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
+			props: { strategiseResults, minCost: 100, budget: 300, selectedStrategy, selectStrategy: vi.fn(), populations }
 		} as any);
 
 		await expect.element(screen.getByText('$100').first()).toBeVisible();
@@ -94,7 +94,7 @@ describe('InterventionGrid', () => {
 			props: {
 				strategiseResults: singleRegionResults,
 				minCost: 0,
-				maxCost: 500,
+				budget: 500,
 				selectedStrategy,
 				selectStrategy: vi.fn(),
 				populations
@@ -111,13 +111,13 @@ describe('InterventionGrid', () => {
 		const screen = render(InterventionGrid, {
 			strategiseResults,
 			minCost: 0,
-			maxCost: 1000,
+			budget: 1000,
 			populations,
 			selectedStrategy,
 			selectStrategy
 		} as any);
 
-		await screen.getByRole('radiogroup').click();
+		await screen.getByRole('button', { name: 'click to select strategy based on budget' }).click();
 
 		await expect.element(screen.getByText('Explored budget')).toBeVisible();
 		await expect.element(screen.getByRole('heading', { name: 'Optimal strategy for selected budget' })).toBeVisible();

--- a/client/src/tests/routes/projects/[project]/strategise/_components/StrategiseResults.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/strategise/_components/StrategiseResults.svelte.spec.ts
@@ -51,7 +51,7 @@ describe('StrategiseResults', () => {
 				strategiseResults,
 				populations,
 				minCost,
-				maxCost
+				budget: maxCost
 			}
 		} as any);
 
@@ -67,7 +67,7 @@ describe('StrategiseResults', () => {
 				strategiseResults,
 				populations,
 				minCost,
-				maxCost
+				budget: maxCost
 			}
 		} as any);
 

--- a/client/src/tests/routes/projects/[project]/strategise/_components/StrategiseResults.svelte.spec.ts
+++ b/client/src/tests/routes/projects/[project]/strategise/_components/StrategiseResults.svelte.spec.ts
@@ -3,52 +3,55 @@ import StrategiseResultsComponent from '$routes/projects/[project]/strategise/_c
 import { render } from 'vitest-browser-svelte';
 
 describe('StrategiseResults', () => {
+	const populations = {
+		'Region A': 1000,
+		'Region B': 2000
+	};
+	const minCost = 100;
+	const maxCost = 1000;
+	const strategiseResults: StrategiseResults = [
+		{
+			costThreshold: 500,
+			interventions: [
+				{
+					region: 'Region A',
+					intervention: 'irs_only',
+					cost: 400,
+					casesAverted: 50
+				},
+				{
+					region: 'Region B',
+					intervention: 'lsm_only',
+					cost: 300,
+					casesAverted: 80
+				}
+			]
+		},
+		{
+			costThreshold: 1000,
+			interventions: [
+				{
+					region: 'Region A',
+					intervention: 'py_only_only',
+					cost: 400,
+					casesAverted: 50
+				},
+				{
+					region: 'Region B',
+					intervention: 'py_ppf_only',
+					cost: 600,
+					casesAverted: 100
+				}
+			]
+		}
+	];
 	it('should render chart and selected strategy info', async () => {
-		const populations = {
-			'Region A': 1000,
-			'Region B': 2000
-		};
-		const strategiseResults: StrategiseResults = [
-			{
-				costThreshold: 500,
-				interventions: [
-					{
-						region: 'Region A',
-						intervention: 'irs_only',
-						cost: 400,
-						casesAverted: 50
-					},
-					{
-						region: 'Region B',
-						intervention: 'lsm_only',
-						cost: 300,
-						casesAverted: 80
-					}
-				]
-			},
-			{
-				costThreshold: 1000,
-				interventions: [
-					{
-						region: 'Region A',
-						intervention: 'py_only_only',
-						cost: 400,
-						casesAverted: 50
-					},
-					{
-						region: 'Region B',
-						intervention: 'py_ppf_only',
-						cost: 600,
-						casesAverted: 100
-					}
-				]
-			}
-		];
-
 		const screen = render(StrategiseResultsComponent, {
 			props: {
 				strategiseResults,
-				populations
+				populations,
+				minCost,
+				maxCost
 			}
 		} as any);
 
@@ -56,5 +59,22 @@ describe('StrategiseResults', () => {
 		await expect.element(screen.getByRole('button', { name: 'Show Region A' })).toBeVisible();
 		await expect.element(screen.getByRole('button', { name: 'Show Region B' })).toBeVisible();
 		await expect.element(screen.getByRole('heading', { name: 'Optimal Strategy for selected' })).toBeVisible();
+	});
+
+	it('should be able to switch tabs to display intervention grid', async () => {
+		const screen = render(StrategiseResultsComponent, {
+			props: {
+				strategiseResults,
+				populations,
+				minCost,
+				maxCost
+			}
+		} as any);
+
+		await expect.element(screen.getByRole('tab', { name: 'Cases Averted Chart' })).toBeVisible();
+
+		await screen.getByRole('tab', { name: 'Allocation Grid' }).click();
+
+		await expect.element(screen.getByText('Intervention Allocation by Cost of Strategy')).toBeInTheDocument();
 	});
 });

--- a/client/src/tests/routes/projects/[project]/strategise/utils.spec.ts
+++ b/client/src/tests/routes/projects/[project]/strategise/utils.spec.ts
@@ -10,6 +10,8 @@ import {
 	createGridRows,
 	getCasesAndCostsForCompareStrategise,
 	getCasesAvertedAndCostsForStrategise,
+	getGridLegendItems,
+	getGridTicks,
 	getMaximumCostForStrategise,
 	getMinimumCostForStrategise,
 	optimiseForMinCases,
@@ -737,5 +739,80 @@ describe('createGridRows', () => {
 				]
 			}
 		]);
+	});
+});
+
+describe('getGridTicks', () => {
+	it('should return 9 evenly spaced ticks from minCost to minCost + costRange', () => {
+		const ticks = getGridTicks(0, 800);
+
+		expect(ticks).toHaveLength(9);
+		expect(ticks[0]).toBe(0);
+		expect(ticks[8]).toBe(800);
+		expect(ticks[4]).toBe(400);
+	});
+
+	it('should offset all ticks by minCost', () => {
+		const ticks = getGridTicks(100, 400);
+
+		expect(ticks[0]).toBe(100);
+		expect(ticks[8]).toBe(500);
+	});
+
+	it('should return 9 identical values when costRange is 0', () => {
+		const ticks = getGridTicks(50, 0);
+
+		expect(ticks).toHaveLength(9);
+		expect(ticks.every((t) => t === 50)).toBe(true);
+	});
+});
+
+describe('getGridLegendItems', () => {
+	it('should return unique scenarios across all rows and blocks', () => {
+		const rows = [
+			{
+				region: 'Region A',
+				blocks: [
+					{ intervention: 'no_intervention' as const, startCost: 0, endCost: 100 },
+					{ intervention: 'irs_only' as const, startCost: 100, endCost: 200 }
+				]
+			},
+			{
+				region: 'Region B',
+				blocks: [
+					{ intervention: 'irs_only' as const, startCost: 0, endCost: 150 },
+					{ intervention: 'lsm_only' as const, startCost: 150, endCost: 200 }
+				]
+			}
+		];
+
+		const result = getGridLegendItems(rows);
+
+		expect([...result]).toEqual(['no_intervention', 'irs_only', 'lsm_only']);
+	});
+
+	it('should deduplicate scenarios appearing in multiple regions', () => {
+		const rows = [
+			{
+				region: 'Region A',
+				blocks: [{ intervention: 'irs_only' as const, startCost: 0, endCost: 100 }]
+			},
+			{
+				region: 'Region B',
+				blocks: [{ intervention: 'irs_only' as const, startCost: 0, endCost: 100 }]
+			}
+		];
+
+		const result = getGridLegendItems(rows);
+
+		expect([...result]).toEqual(['irs_only']);
+	});
+
+	it('should return an empty set for rows with no blocks', () => {
+		const rows = [{ region: 'Region A', blocks: [] }];
+
+		const result = getGridLegendItems(rows);
+
+		expect([...result]).toEqual([]);
 	});
 });

--- a/client/src/tests/routes/projects/[project]/strategise/utils.spec.ts
+++ b/client/src/tests/routes/projects/[project]/strategise/utils.spec.ts
@@ -7,6 +7,7 @@ import type { StrategiseRegionByMetric } from '$routes/projects/[project]/strate
 import {
 	buildInterventions,
 	constructRegionalMetrics,
+	createGridRows,
 	getCasesAndCostsForCompareStrategise,
 	getCasesAvertedAndCostsForStrategise,
 	getMaximumCostForStrategise,
@@ -618,5 +619,123 @@ describe('parseOptimisationResult', () => {
 			cost: 250,
 			cases: 120
 		});
+	});
+});
+describe('createGridRows', () => {
+	it('should return an empty array when strategise results are empty', async () => {
+		const { createGridRows } = await import('$routes/projects/[project]/strategise/utils');
+
+		expect(createGridRows([], 100)).toEqual([]);
+	});
+
+	it('should create merged blocks across thresholds and close final block at maxCost', async () => {
+		const { createGridRows } = await import('$routes/projects/[project]/strategise/utils');
+
+		const strategiseResults = [
+			{
+				costThreshold: 0,
+				interventions: [{ region: 'Region A', intervention: 'no_intervention', cost: 0, casesAverted: 0 }]
+			},
+			{
+				costThreshold: 100,
+				interventions: [{ region: 'Region A', intervention: 'irs_only', cost: 100, casesAverted: 10 }]
+			},
+			{
+				costThreshold: 200,
+				interventions: [{ region: 'Region A', intervention: 'irs_only', cost: 100, casesAverted: 10 }]
+			},
+			{
+				costThreshold: 300,
+				interventions: [{ region: 'Region A', intervention: 'lsm_only', cost: 200, casesAverted: 20 }]
+			}
+		] as any;
+
+		const result = createGridRows(strategiseResults, 400);
+
+		expect(result).toEqual([
+			{
+				region: 'Region A',
+				blocks: [
+					{ intervention: 'no_intervention', startCost: 0, endCost: 100 },
+					{ intervention: 'irs_only', startCost: 100, endCost: 300 },
+					{ intervention: 'lsm_only', startCost: 300, endCost: 400 }
+				]
+			}
+		]);
+	});
+
+	it('should create blocks per region independently and preserve region order from first threshold', async () => {
+		const strategiseResults = [
+			{
+				costThreshold: 10,
+				interventions: [
+					{ region: 'Region A', intervention: 'no_intervention', cost: 0, casesAverted: 0 },
+					{ region: 'Region B', intervention: 'irs_only', cost: 50, casesAverted: 5 }
+				]
+			},
+			{
+				costThreshold: 20,
+				interventions: [
+					{ region: 'Region A', intervention: 'irs_only', cost: 50, casesAverted: 5 },
+					{ region: 'Region B', intervention: 'irs_only', cost: 50, casesAverted: 5 }
+				]
+			},
+			{
+				costThreshold: 30,
+				interventions: [
+					{ region: 'Region A', intervention: 'irs_only', cost: 50, casesAverted: 5 },
+					{ region: 'Region B', intervention: 'lsm_only', cost: 100, casesAverted: 10 }
+				]
+			}
+		] as any;
+
+		const result = createGridRows(strategiseResults, 40);
+
+		expect(result).toEqual([
+			{
+				region: 'Region A',
+				blocks: [
+					{ intervention: 'no_intervention', startCost: 10, endCost: 20 },
+					{ intervention: 'irs_only', startCost: 20, endCost: 40 }
+				]
+			},
+			{
+				region: 'Region B',
+				blocks: [
+					{ intervention: 'irs_only', startCost: 10, endCost: 30 },
+					{ intervention: 'lsm_only', startCost: 30, endCost: 40 }
+				]
+			}
+		]);
+	});
+
+	it('should ignore regions not present in the first strategise result', async () => {
+		const { createGridRows } = await import('$routes/projects/[project]/strategise/utils');
+
+		const strategiseResults = [
+			{
+				costThreshold: 0,
+				interventions: [{ region: 'Region A', intervention: 'no_intervention', cost: 0, casesAverted: 0 }]
+			},
+			{
+				costThreshold: 50,
+				interventions: [
+					{ region: 'Region A', intervention: 'irs_only', cost: 50, casesAverted: 5 },
+					{ region: 'Region C', intervention: 'lsm_only', cost: 100, casesAverted: 10 }
+				]
+			}
+		] as any;
+
+		const result = createGridRows(strategiseResults, 100);
+
+		expect(result).toEqual([
+			{
+				region: 'Region A',
+				blocks: [
+					{ intervention: 'no_intervention', startCost: 0, endCost: 50 },
+					{ intervention: 'irs_only', startCost: 50, endCost: 100 }
+				]
+			}
+		]);
 	});
 });


### PR DESCRIPTION
A new view for strategise that was requested has been added. The first image is what they wanted (the x-axis and y-axis show different regions, coloured by intervention). The wording is subject to change as i will put on dev and get feedback from tom/jack.

Testing: (can use [mint-dev](https://mint-dev.dide.ic.ac.uk/) or local)
First run multiple regions and then head to strategise. Then test following
- see allocation grid view
- be able to click on grid and see explored strategy
- sync of explored budget with chart view and grid view
- play around and see if all works as expected

<img width="731" height="373" alt="image" src="https://github.com/user-attachments/assets/99167b8a-9752-4ad4-a596-afc5115b4c39" />

<img width="1234" height="773" alt="image" src="https://github.com/user-attachments/assets/72771f71-f7e1-48ac-96b6-9ceb4bfba36e" />