### PR TITLE
Change longterm line chart to bar chart

### DIFF
--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -86,168 +86,79 @@ export const getCasesConfig = (casesAverted: Partial<Record<Scenario, CasesAvert
 	};
 };
 
-interface CasesCompareDataPoint {
-	scenario: Scenario;
-	totalCases: number;
-	totalCost: number;
-}
-export const filterInefficientStrategies = (dataPoints: CasesCompareDataPoint[]): CasesCompareDataPoint[] => {
-	const sortedByCost = [...dataPoints].sort((a, b) => a.totalCost - b.totalCost);
-	return sortedByCost.reduce<CasesCompareDataPoint[]>((acc, current) => {
-		const previous = acc[acc.length - 1];
-		if (!previous || current.totalCases < previous.totalCases) {
-			acc.push(current);
-		}
-		return acc;
-	}, []);
-};
-export const createCasesCompareDataPoints = (
-	totalCasesAndCosts: Partial<Record<Scenario, ScenarioTotals>>
-): CasesCompareDataPoint[] => {
-	const totalCasesAndCostsArray = Object.entries(totalCasesAndCosts).map(([scenario, { totalCases, totalCost }]) => ({
-		scenario: scenario as Scenario,
-		totalCases,
-		totalCost: totalCost
-	}));
-
-	return filterInefficientStrategies(totalCasesAndCostsArray);
-};
-
 export const createCasesCompareSeries = (
 	totalCasesAndCosts: Partial<Record<Scenario, ScenarioTotals>>,
 	name:
 		| 'Present (current control strategies)'
 		| 'Long-term (adjusted control strategies)'
 		| 'Long-term (current control strategies)'
-): SeriesLineOptions => ({
+): SeriesColumnOptions => ({
 	name,
-	type: 'line',
-	data: createCasesCompareDataPoints(totalCasesAndCosts).map(({ totalCases, totalCost, scenario }) => ({
-		x: totalCost,
+	type: 'column',
+	data: Object.entries(totalCasesAndCosts).map(([scenario, { totalCases, totalCost }]) => ({
+		name: ScenarioToLabel[scenario as Scenario],
 		y: totalCases,
-		custom: {
-			intervention: ScenarioToLabel[scenario as Scenario]
+		dataLabels: {
+			enabled: true,
+			rotation: -90,
+			inside: true,
+			crop: false,
+			format: `$${convertToLocaleString(totalCost, 0)}`
 		}
-	})),
-	step: 'left'
+	}))
 });
 
-/**
- * The function creates an x-axis break to minimize the empty space between the first and second data points.
- * This is because the first point is always at x=0 (no intervention), and the second point can be far away, leading to a large empty space on the chart.
- */
-export const createBreakToMinimizeEmptySpace = (
-	data1: PointOptionsObject[],
-	data2: PointOptionsObject[]
-): Highcharts.XAxisBreaksOptions[] | undefined => {
-	const getSecondPoint = (data: PointOptionsObject[]): number => (data.length > 1 ? (data[1].x as number) : Infinity);
-
-	const data1Breakpoint = getSecondPoint(data1);
-	const data2Breakpoint = getSecondPoint(data2);
-
-	const breakPoint = Math.min(data1Breakpoint, data2Breakpoint) * 0.9; // set break point at 90%
-	const breakSize = breakPoint * 0.2; // add a 20% buffer to ensure the break is visible
-
-	return breakPoint !== Infinity ? [{ from: 0, to: breakPoint, breakSize }] : undefined;
-};
-
-const resetSeriesPointStates = (seriesList: Highcharts.Series[]) => {
-	seriesList.forEach((s) => s.points.forEach((p) => p.setState('')));
-};
-export const createCompareTooltipHtml = function (this: Highcharts.Point): string {
-	const currentIntervention: string = this.options.custom!.intervention;
-	const tooltipLines: string[] = [`<div class="mb-1"><span class="font-semibold ">${currentIntervention}</span></div>`];
-
-	for (const series of this.series.chart.series) {
-		resetSeriesPointStates([series]);
-
-		const point = series.points.find((p) => p.options.custom!.intervention === currentIntervention);
-		if (!point) continue;
-
-		point.setState('hover');
-		tooltipLines.push(`
-			<div class="flex items-center">
-				<span style="color:${series.color};" class="mr-1">●</span>
-				<span class="text-muted-foreground">${series.name}:</span>
-				<span class="ml-0.5">${convertToLocaleString(point.y as number, 1)} cases • $${convertToLocaleString(point.x, 0)}</span>
-			</div>
-		`);
-	}
-
-	return tooltipLines.join('');
-};
-
-export const getClosestPoint = (cost: number, allSeries: Highcharts.Series[]): Highcharts.Point | null =>
-	allSeries
-		.flatMap((series) => series.data)
-		.reduce<Highcharts.Point | null>((closest, point) => {
-			if (closest === null) return point;
-			return Math.abs((point.x as number) - cost) < Math.abs((closest.x as number) - cost) ? point : closest;
-		}, null);
-
-export const getCasesCompareConfig = ({
-	presentTotals,
-	baselineLongTermTotals,
-	fullLongTermTotals
-}: CompareTotals): Options => {
+export const getCasesCompareConfig = (
+	{ presentTotals, baselineLongTermTotals, fullLongTermTotals }: CompareTotals,
+	scenarios: Scenario[]
+): Options => {
 	const presentSeries = createCasesCompareSeries(presentTotals, 'Present (current control strategies)');
 	const baselineLongTermSeries = createCasesCompareSeries(
 		baselineLongTermTotals,
 		'Long-term (current control strategies)'
 	);
 	const fullLongTermSeries = createCasesCompareSeries(fullLongTermTotals, 'Long-term (adjusted control strategies)');
-	const presentData = presentSeries.data as PointOptionsObject[];
 	const fullLongTermData = fullLongTermSeries.data as PointOptionsObject[];
 
 	return {
 		chart: {
-			type: 'line',
+			type: 'column',
 			height: 450
 		},
 		title: {
 			text: 'Total Clinical Cases and Cost of Strategy'
 		},
-		subtitle: {
-			text: 'Step lines show the most cost-effective intervention at each cost level',
-			style: {
-				color: 'var(--muted-foreground)'
+		xAxis: {
+			type: 'category',
+			categories: scenarios.map((scenario) => ScenarioToLabel[scenario]),
+			crosshair: true,
+			accessibility: {
+				description: 'Intervention types'
 			}
 		},
-		caption: {
-			text: 'Only the most cost-effective interventions are plotted, see Table tab for all options',
+		subtitle: {
+			text: 'The number of cases is shown on the y-axis, and the cost of the strategy is shown in the data labels.',
 			align: 'left',
 			verticalAlign: 'bottom',
 			style: {
 				color: 'var(--muted-foreground)'
 			}
 		},
-		xAxis: {
-			title: { text: 'Total cost ($USD)' },
-			labels: { format: '${value:,.0f}' },
-			min: 0,
-			breaks: createBreakToMinimizeEmptySpace(presentData, fullLongTermData)
-		},
 		yAxis: {
 			title: { text: 'Total cases' },
 			labels: { format: '{value:,.0f}' }
 		},
 		tooltip: {
-			shadow: true,
-			useHTML: true,
-			formatter: createCompareTooltipHtml
+			shared: true,
+			valueDecimals: 1,
+			style: {
+				opacity: 0.8
+			},
+			headerFormat: '<span style="font-size: 10px; font-weight: bold;">Total Cases</span><br/>'
 		},
 		plotOptions: {
-			line: {
-				states: {
-					inactive: {
-						enabled: false
-					}
-				},
-				events: {
-					mouseOut: function () {
-						resetSeriesPointStates(this.chart.series);
-					}
-				}
+			column: {
+				groupPadding: 0.15
 			}
 		},
 		legend: { enabled: true },

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -98,13 +98,16 @@ export const createCasesCompareSeries = (
 	data: Object.entries(totalCasesAndCosts).map(([scenario, { totalCases, totalCost }]) => ({
 		name: ScenarioToLabel[scenario as Scenario],
 		y: totalCases,
-		dataLabels: {
-			enabled: true,
-			rotation: -90,
-			inside: true,
-			crop: false,
-			format: `$${convertToLocaleString(totalCost, 0)}`
-		}
+		...(name !== 'Long-term (current control strategies)' && {
+			dataLabels: {
+				enabled: true,
+				rotation: -90,
+				inside: true,
+				allowOverlap: true,
+				crop: false,
+				format: `$${convertToLocaleString(totalCost, 0)}`
+			}
+		})
 	}))
 });
 

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -111,6 +111,23 @@ export const createCasesCompareSeries = (
 	}))
 });
 
+const CASES_COMPARE_PLOTLINE_ID = 'cases-compare-plotline';
+const addCasesComparePlotLine = (chart: Highcharts.Chart, value: number) => {
+	chart.yAxis[0].removePlotLine(CASES_COMPARE_PLOTLINE_ID);
+	chart.yAxis[0].addPlotLine({
+		id: CASES_COMPARE_PLOTLINE_ID,
+		value,
+		color: 'var(--foreground)',
+		dashStyle: 'ShortDot',
+		width: 2,
+		zIndex: 5,
+		label: {
+			text: `Selected scenario`,
+			style: { color: 'var(--foreground)', fontWeight: '550' }
+		}
+	});
+};
+
 export const getCasesCompareConfig = (
 	{ presentTotals, baselineLongTermTotals, fullLongTermTotals }: CompareTotals,
 	scenarios: Scenario[]
@@ -140,7 +157,7 @@ export const getCasesCompareConfig = (
 			}
 		},
 		subtitle: {
-			text: 'The number of cases is shown on the y-axis, and the cost of the strategy is shown in the data labels.',
+			text: 'The number of cases is shown on the y-axis, and the cost of the strategy is shown in the data labels.<br/>Click on a column to compare the number of cases with the other strategies.',
 			align: 'left',
 			verticalAlign: 'bottom',
 			style: {
@@ -161,7 +178,12 @@ export const getCasesCompareConfig = (
 		},
 		plotOptions: {
 			column: {
-				groupPadding: 0.15
+				groupPadding: 0.15,
+				events: {
+					click: function (event) {
+						addCasesComparePlotLine(this.chart, event.point.y!);
+					}
+				}
 			}
 		},
 		legend: { enabled: true },

--- a/client/src/lib/charts/casesConfig.ts
+++ b/client/src/lib/charts/casesConfig.ts
@@ -150,7 +150,7 @@ export const getCasesCompareConfig = (
 		},
 		tooltip: {
 			shared: true,
-			valueDecimals: 1,
+			valueDecimals: 0,
 			style: {
 				opacity: 0.8
 			},

--- a/client/src/routes/projects/[project]/regions/[region]/compare/+page.server.ts
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/+page.server.ts
@@ -1,5 +1,6 @@
 import { fetchCompareParameters, fetchLongTermResults } from '$lib/server/compare';
 import { getRegionFromUserState } from '$lib/server/region';
+import type { CompareParameters } from '$lib/types/compare';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, locals, fetch }) => {
@@ -7,7 +8,7 @@ export const load: PageServerLoad = async ({ params, locals, fetch }) => {
 
 	const regionData = getRegionFromUserState(locals.userState, project, region);
 
-	const compareParameters = await fetchCompareParameters(fetch);
+	const compareParameters: CompareParameters = await fetchCompareParameters(fetch);
 
 	return {
 		region: regionData,

--- a/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
+++ b/client/src/routes/projects/[project]/regions/[region]/compare/_components/CompareResults.svelte
@@ -34,11 +34,11 @@
 	});
 
 	let selectedIntervention = $state<ScenarioLabel>('No Intervention');
-	let casesConfig = $derived(getCasesCompareConfig(totals));
 
 	let scenarios = $derived(
 		getScenariosFromTotals(totals.presentTotals, totals.baselineLongTermTotals, totals.fullLongTermTotals)
 	);
+	let casesConfig = $derived(getCasesCompareConfig(totals, scenarios));
 	let selectedTab = $state<'graph' | 'table'>('graph');
 	let tableData = $derived(buildCompareCasesTableData(totals, scenarios));
 	let prevalenceConfig = $derived(getPrevalenceConfigCompare(results, selectedIntervention));

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -281,5 +281,35 @@ describe('cases compare config', () => {
 			expect(config.series).toHaveLength(1);
 			expect((config.series as any)[0].name).toBe('Present (current control strategies)');
 		});
+
+		it('should add plot line on column click', () => {
+			const mockSeries = {
+				chart: {
+					yAxis: [
+						{
+							removePlotLine: vi.fn(),
+							addPlotLine: vi.fn()
+						}
+					]
+				}
+			} as unknown as Highcharts.Series;
+			const mockEvent = {
+				point: {
+					y: 500
+				}
+			} as unknown as Highcharts.SeriesClickEventObject;
+
+			const config = getCasesCompareConfig(compareTotals, scenarios);
+
+			config.plotOptions!.column!.events!.click!.call(mockSeries, mockEvent);
+
+			expect(mockSeries.chart.yAxis[0].removePlotLine).toHaveBeenCalledWith('cases-compare-plotline');
+			expect(mockSeries.chart.yAxis[0].addPlotLine).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: 'cases-compare-plotline',
+					value: 500
+				})
+			);
+		});
 	});
 });

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -1,17 +1,7 @@
-import {
-	createBreakToMinimizeEmptySpace,
-	createCasesCompareDataPoints,
-	createCasesCompareSeries,
-	createCompareTooltipHtml,
-	filterInefficientStrategies,
-	getCasesCompareConfig,
-	getCasesConfig,
-	getClosestPoint
-} from '$lib/charts/casesConfig';
+import { createCasesCompareSeries, getCasesCompareConfig, getCasesConfig } from '$lib/charts/casesConfig';
 import * as processCases from '$lib/process-results/processCases';
 import type { CompareTotals } from '$lib/types/compare';
 import type { Scenario } from '$lib/types/userState';
-import type { PointOptionsObject } from 'highcharts';
 import { describe, expect, it } from 'vitest';
 describe('getCasesConfig', () => {
 	const mockCasesAverted: Partial<Record<Scenario, processCases.CasesAverted>> = {
@@ -210,296 +200,58 @@ describe('cases compare config', () => {
 			totalCases: 300
 		}
 	};
+	const scenarios = Object.keys(totals) as Scenario[];
 	const compareTotals: CompareTotals = {
 		presentTotals: totals,
 		baselineLongTermTotals: totals,
 		fullLongTermTotals: totals
 	};
 
-	describe('getClosesPoint', () => {
-		it('getClosestPoint should return null for empty series data', () => {
-			const result = getClosestPoint(1000, [] as any[]);
-			expect(result).toBeNull();
-		});
-
-		it('getClosestPoint should return nearest point across all series', () => {
-			const p1 = { x: 1000, options: { custom: { intervention: 'A' } } };
-			const p2 = { x: 2600, options: { custom: { intervention: 'B' } } };
-			const p3 = { x: 1800, options: { custom: { intervention: 'C' } } };
-
-			const allSeries = [{ data: [p1, p2] }, { data: [p3] }] as any[];
-
-			const result = getClosestPoint(2000, allSeries);
-
-			expect(result).toBe(p3);
-		});
-
-		it('getClosestPoint should keep first encountered point on distance tie', () => {
-			const left = { x: 100, options: { custom: { intervention: 'Left' } } };
-			const right = { x: 300, options: { custom: { intervention: 'Right' } } };
-			const allSeries = [{ data: [left, right] }] as any[];
-
-			const result = getClosestPoint(200, allSeries);
-
-			expect(result).toBe(left);
-		});
-	});
-	describe('filterInefficientStrategies', () => {
-		it('filterInefficientStrategies should sort by cost and keep only strictly improving strategies', () => {
-			const input = [
-				{ scenario: 'irs_only', totalCost: 5000, totalCases: 1000 },
-				{ scenario: 'py_only_only', totalCost: 2000, totalCases: 1200 },
-				{ scenario: 'py_only_with_lsm', totalCost: 3000, totalCases: 1100 },
-				{ scenario: 'irs_only', totalCost: 4000, totalCases: 1150 }
-			] as any[];
-
-			const result = filterInefficientStrategies(input);
-
-			expect(result).toEqual([
-				{ scenario: 'py_only_only', totalCost: 2000, totalCases: 1200 },
-				{ scenario: 'py_only_with_lsm', totalCost: 3000, totalCases: 1100 },
-				{ scenario: 'irs_only', totalCost: 5000, totalCases: 1000 }
-			]);
-		});
-
-		it('filterInefficientStrategies should drop equal-cases higher-cost points', () => {
-			const input = [
-				{ scenario: 'irs_only', totalCost: 1000, totalCases: 1000 },
-				{ scenario: 'py_only_only', totalCost: 2000, totalCases: 1000 }
-			] as any[];
-
-			const result = filterInefficientStrategies(input);
-
-			expect(result).toHaveLength(1);
-			expect(result[0]).toEqual({ scenario: 'irs_only', totalCost: 1000, totalCases: 1000 });
-		});
-	});
-	describe('createCasesCompareDataPoints', () => {
-		it('should return data points filtering out inefficient strategies', () => {
-			const result = createCasesCompareDataPoints(totals);
-
-			expect(result).toEqual([
-				{ scenario: 'py_only_only', totalCases: 500, totalCost: 1000 },
-				{ scenario: 'lsm_only', totalCases: 300, totalCost: 1200 }
-			]);
-		});
-
-		it('should handle empty object', () => {
-			const result = createCasesCompareDataPoints({});
-			expect(result).toEqual([]);
-		});
-	});
-
 	describe('createCasesCompareSeries', () => {
 		it('should create a series with correct name and data points', () => {
 			const series = createCasesCompareSeries(totals, 'Present (current control strategies)');
 
 			expect(series.name).toBe('Present (current control strategies)');
-			expect(series.type).toBe('line');
-			expect(series.step).toBe('left');
+			expect(series.type).toBe('column');
 
-			expect(series.data).toHaveLength(2);
+			expect(series.data).toHaveLength(3);
 			expect(series.data![0]).toEqual({
-				x: 1000,
+				name: 'Pyrethroid ITN (Only)',
 				y: 500,
-				custom: { intervention: 'Pyrethroid ITN (Only)' }
+				dataLabels: expect.objectContaining({
+					format: '$1,000'
+				})
 			});
 			expect(series.data![1]).toEqual({
-				x: 1200,
-				y: 300,
-				custom: { intervention: 'LSM Only' }
+				name: 'IRS Only',
+				y: 600,
+				dataLabels: expect.objectContaining({
+					format: '$1,100'
+				})
 			});
-		});
-	});
-
-	describe('createBreakToMinimizeEmptySpace', () => {
-		it('should return undefined when both datasets have only one point', () => {
-			const data1: PointOptionsObject[] = [{ x: 1000, y: 500 }];
-			const data2: PointOptionsObject[] = [{ x: 2000, y: 600 }];
-
-			const result = createBreakToMinimizeEmptySpace(data1, data2);
-
-			expect(result).toBeUndefined();
-		});
-
-		it('should calculate break point based on the smaller second x value', () => {
-			const data1: PointOptionsObject[] = [
-				{ x: 0, y: 100 },
-				{ x: 5000, y: 200 }
-			];
-			const data2: PointOptionsObject[] = [
-				{ x: 0, y: 150 },
-				{ x: 3000, y: 250 }
-			];
-
-			const result = createBreakToMinimizeEmptySpace(data1, data2);
-
-			expect(result).toHaveLength(1);
-			expect(result![0].from).toBe(0);
-			expect(result![0].to).toBe(3000 * 0.9);
-		});
-
-		it('should set break size to 20% of the break point', () => {
-			const data1: PointOptionsObject[] = [
-				{ x: 0, y: 100 },
-				{ x: 10000, y: 200 }
-			];
-			const data2: PointOptionsObject[] = [
-				{ x: 0, y: 150 },
-				{ x: 5000, y: 250 }
-			];
-
-			const result = createBreakToMinimizeEmptySpace(data1, data2);
-
-			expect(result).toHaveLength(1);
-			expect(result![0].breakSize).toBe(5000 * 0.9 * 0.2);
-		});
-	});
-
-	describe('createCompareTooltipHtml', () => {
-		it('should include data from all series with matching intervention', () => {
-			const mockPoint1 = {
-				setState: vi.fn(),
-				options: { custom: { intervention: 'IRS Only' } },
-				y: 1500,
-				x: 5000
-			};
-			const mockPoint2 = {
-				setState: vi.fn(),
-				options: { custom: { intervention: 'Pyrethroid ITN (Only)' } },
-				y: 2000,
-				x: 3000
-			};
-			const mockPoint3 = {
-				setState: vi.fn(),
-				options: { custom: { intervention: 'IRS Only' } },
-				y: 1800,
-				x: 6000
-			};
-
-			const mockSeries1 = {
-				name: 'Present',
-				color: '#ff0000',
-				points: [mockPoint1, mockPoint2]
-			};
-			const mockSeries2 = {
-				name: 'Long term',
-				color: '#00ff00',
-				points: [mockPoint3]
-			};
-
-			const mockThis = {
-				options: {
-					custom: { intervention: 'IRS Only' }
-				},
-				series: {
-					chart: {
-						series: [mockSeries1, mockSeries2]
-					}
-				}
-			} as any;
-
-			const result = createCompareTooltipHtml.call(mockThis);
-
-			expect(result).toContain('<div class="mb-1"><span class="font-semibold ">IRS Only</span></div>');
-			expect(result).toContain('Present');
-			expect(result).toContain('Long term');
-			expect(result).toContain('1,500.0 cases');
-			expect(result).toContain('$5,000');
-			expect(result).toContain('1,800.0 cases');
-			expect(result).toContain('$6,000');
-			expect(result).not.toContain('2,000.0 cases');
-		});
-
-		it('should set hover state on matching points', () => {
-			const mockPoint1 = {
-				setState: vi.fn(),
-				options: { custom: { intervention: 'IRS Only' } },
-				y: 1500,
-				x: 5000
-			};
-			const mockPoint2 = {
-				setState: vi.fn(),
-				options: { custom: { intervention: 'IRS Only' } },
-				y: 1800,
-				x: 6000
-			};
-
-			const mockSeries1 = {
-				name: 'Present',
-				color: '#ff0000',
-				points: [mockPoint1]
-			};
-			const mockSeries2 = {
-				name: 'Long term',
-				color: '#00ff00',
-				points: [mockPoint2]
-			};
-
-			const mockThis = {
-				options: {
-					custom: { intervention: 'IRS Only' }
-				},
-				series: {
-					chart: {
-						series: [mockSeries1, mockSeries2]
-					}
-				}
-			} as any;
-
-			createCompareTooltipHtml.call(mockThis);
-
-			expect(mockPoint1.setState).toHaveBeenCalledWith('');
-			expect(mockPoint1.setState).toHaveBeenCalledWith('hover');
-			expect(mockPoint2.setState).toHaveBeenCalledWith('');
-			expect(mockPoint2.setState).toHaveBeenCalledWith('hover');
-		});
-
-		it('should format large numbers with locale string', () => {
-			const mockPoint = {
-				setState: vi.fn(),
-				options: { custom: { intervention: 'IRS Only' } },
-				y: 1234567.89,
-				x: 9876543.21
-			};
-
-			const mockSeries = {
-				name: 'Present',
-				color: '#ff0000',
-				points: [mockPoint]
-			};
-
-			const mockThis = {
-				options: {
-					custom: { intervention: 'IRS Only' }
-				},
-				series: {
-					chart: {
-						series: [mockSeries]
-					}
-				}
-			} as any;
-
-			const result = createCompareTooltipHtml.call(mockThis);
-
-			expect(result).toContain('1,234,567.9 cases');
-			expect(result).toContain('$9,876,543');
+			expect(series.data![2]).toEqual({
+				name: 'LSM Only',
+				y: 300,
+				dataLabels: expect.objectContaining({
+					format: '$1,200'
+				})
+			});
 		});
 	});
 
 	describe('getCasesCompareConfig integration', () => {
 		it('should return a valid Highcharts Options object', () => {
-			const config = getCasesCompareConfig(compareTotals);
+			const config = getCasesCompareConfig(compareTotals, scenarios);
 
 			expect(config).toBeDefined();
-			expect(config.chart?.type).toBe('line');
+			expect(config.chart?.type).toBe('column');
 			expect(config.chart?.height).toBe(450);
 			expect(config.title?.text).toBe('Total Clinical Cases and Cost of Strategy');
-			expect(config.subtitle?.text).toBe('Step lines show the most cost-effective intervention at each cost level');
+			expect((config.xAxis as any).type).toBe('category');
 		});
 
 		it('should include both Present and Long term series when newCases has data', () => {
-			const config = getCasesCompareConfig(compareTotals);
+			const config = getCasesCompareConfig(compareTotals, scenarios);
 
 			expect(config.series).toHaveLength(3);
 			expect((config.series as any)[0].name).toBe('Present (current control strategies)');
@@ -510,26 +262,17 @@ describe('cases compare config', () => {
 		it('should include only Present series when newCases is empty', () => {
 			vi.spyOn(processCases, 'collectPostInterventionCases').mockReturnValue({} as any);
 
-			const config = getCasesCompareConfig({
-				presentTotals: totals,
-				baselineLongTermTotals: {},
-				fullLongTermTotals: {}
-			});
+			const config = getCasesCompareConfig(
+				{
+					presentTotals: totals,
+					baselineLongTermTotals: {},
+					fullLongTermTotals: {}
+				},
+				scenarios
+			);
 
 			expect(config.series).toHaveLength(1);
 			expect((config.series as any)[0].name).toBe('Present (current control strategies)');
-		});
-
-		it('should apply breaks to xAxis when data points exist', () => {
-			const config = getCasesCompareConfig(compareTotals);
-
-			expect((config.xAxis as any).breaks).toBeDefined();
-		});
-
-		it('should set tooltip formatter to createCompareTooltipHtml', () => {
-			const config = getCasesCompareConfig(compareTotals);
-
-			expect(config.tooltip?.formatter).toBe(createCompareTooltipHtml);
 		});
 	});
 });

--- a/client/src/tests/lib/charts/casesConfig.spec.ts
+++ b/client/src/tests/lib/charts/casesConfig.spec.ts
@@ -237,6 +237,13 @@ describe('cases compare config', () => {
 				})
 			});
 		});
+		it('should not include data labels for Long-term (current control strategies)', () => {
+			const series = createCasesCompareSeries(totals, 'Long-term (current control strategies)');
+
+			series.data!.forEach((point) => {
+				expect((point as any).dataLabels).toBeUndefined();
+			});
+		});
 	});
 
 	describe('getCasesCompareConfig integration', () => {


### PR DESCRIPTION
After discussions with jack. we have decided to change the long term cases chart to be a grouped bar chart.  This was because the line chart was a bit confusing to interpret. The new bar chart allows us to more easily interpret how cases change with updating baseline parameters and interventions. 


Testing:
Can use mint-dev as its deployed on there. Just run a region and then go to long term. play around with changing formvalues. 


## OLD
<img width="1383" height="484" alt="image" src="https://github.com/user-attachments/assets/a552a9e4-9514-46be-af94-312c3e91ebcf" />
## NEW 
<img width="1383" height="484" alt="image" src="https://github.com/user-attachments/assets/78ceaa85-6113-45c3-8208-589e98bec8ea" />
